### PR TITLE
feat(pipeline): Mode A preliminary on-device classification chips

### DIFF
--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -51,6 +51,14 @@ final class AnalysisViewModel {
     /// The item suggestions returned by vision inference; populated when `phase == .complete`.
     private(set) var suggestions: [SuggestionItem] = []
 
+    /// On-device `VNClassifyImageRequest` classifications, populated the moment
+    /// Stage 3 of `ImagePipeline.process(_:)` succeeds (before `.uploading`).
+    ///
+    /// The parent view uses this to render preliminary chips in
+    /// `SuggestionReviewView` during the ~40 s server call. See
+    /// `thoughts/shared/designs/coreml-mode-a-merge-ux.md`.
+    private(set) var preliminaryClassifications: [ClassificationResult] = []
+
     /// The photo ID from the last successful ingest; `nil` until ingest completes.
     private(set) var lastPhotoId: Int?
 
@@ -79,6 +87,7 @@ final class AnalysisViewModel {
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
     func run(jpegData: Data, binId: String, apiClient: APIClient, context: ModelContext? = nil) async {
         lastQualityFailure = nil
+        preliminaryClassifications = []
 
         // Boxes allow mutation from the synchronously-called expiration handler.
         final class WorkTaskBox: @unchecked Sendable {
@@ -130,6 +139,7 @@ final class AnalysisViewModel {
         do {
             let result = try await pipeline.process(jpegData)
             uploadData = result.optimizedImageData
+            preliminaryClassifications = result.deviceMetadata.deviceProcessing.classifications
             let jsonData = try JSONEncoder().encode(result.deviceMetadata)
             metadataString = String(data: jsonData, encoding: .utf8)
         } catch let error as PipelineError {
@@ -233,6 +243,7 @@ final class AnalysisViewModel {
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
     func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, context: ModelContext? = nil) async {
         lastQualityFailure = nil
+        preliminaryClassifications = []
         phase = .processingImage
 
         var uploadData: Data
@@ -241,6 +252,7 @@ final class AnalysisViewModel {
         do {
             let result = try await pipeline.processSkippingQualityGates(jpegData)
             uploadData = result.optimizedImageData
+            preliminaryClassifications = result.deviceMetadata.deviceProcessing.classifications
             let jsonData = try JSONEncoder().encode(result.deviceMetadata)
             metadataString = String(data: jsonData, encoding: .utf8)
         } catch {
@@ -310,6 +322,7 @@ final class AnalysisViewModel {
     func reset() {
         phase = .idle
         suggestions = []
+        preliminaryClassifications = []
         lastPhotoId = nil
         lastQualityFailure = nil
     }

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -9,6 +9,22 @@ import Foundation
 import Observation
 import OSLog
 
+// MARK: - ChipOrigin
+
+/// Provenance of a `SuggestionReviewViewModel` chip.
+///
+/// Drives visual "preliminary" styling in `SuggestionReviewView` and the
+/// merge rules in `SuggestionReviewViewModel.merge(preliminary:server:)`.
+/// See `thoughts/shared/designs/coreml-mode-a-merge-ux.md` §2a.
+enum ChipOrigin: Equatable {
+    /// On-device `VNClassifyImageRequest` top-K result shown pre-server-response.
+    case preliminary
+    /// Produced by the server's `/ingest` suggestion response.
+    case server
+    /// Modified by the user; survives any merge pass.
+    case edited
+}
+
 // MARK: - EditableSuggestion
 
 /// A mutable wrapper around a `SuggestionItem` for the review UI.
@@ -38,11 +54,18 @@ struct EditableSuggestion: Identifiable {
     var isMatched: Bool { match != nil }
     /// Whether the user wants to teach this item name as a YOLO-World class.
     var teach: Bool
+    /// Chip provenance — drives preliminary styling and merge rules.
+    var origin: ChipOrigin = .server
 }
 
 // MARK: - SuggestionReviewViewModel
 
 private let logger = Logger(subsystem: "com.binbrain.app", category: "SuggestionReview")
+#if DEBUG
+/// Debug-only logger for on-device top-K vs. user-confirmed labels (Phase 1.2,
+/// §9 of the design doc). On-device-only by T2; never uploaded.
+private let preliminaryDebugLogger = Logger(subsystem: "com.binbrain.app", category: "PreliminaryDebug")
+#endif
 
 /// Manages the review + confirmation step of the cataloging workflow.
 ///
@@ -70,6 +93,12 @@ final class SuggestionReviewViewModel {
     /// confirmation; teach failures are secondary. Resets at the start of each
     /// `confirm` invocation so views can surface a toast when > 0.
     private(set) var teachFailureCount: Int = 0
+
+    /// Snapshot of the on-device top-K classifications captured at
+    /// `loadPreliminaryClassifications(_:topK:)` time. Used by the `#if DEBUG`
+    /// logger in `confirm(...)` to emit (top-K vs. confirmed label) pairs.
+    /// Never uploaded — Phase 0 T2 decision is on-device-only.
+    private var originalPreliminaryTopK: [ClassificationResult] = []
 
     // MARK: - Setup
 
@@ -139,6 +168,22 @@ final class SuggestionReviewViewModel {
             }
         }
 
+        #if DEBUG
+        // On-device-only debug log: top-K vs. user-confirmed labels.
+        // Never uploaded; gated behind #if DEBUG per Phase 0 T2 decision.
+        if !originalPreliminaryTopK.isEmpty {
+            let topK = originalPreliminaryTopK
+                .map { "\($0.label):\(String(format: "%.2f", $0.confidence))" }
+                .joined(separator: ",")
+            let confirmed = includedIndices
+                .map { editableSuggestions[$0].editedName }
+                .joined(separator: ",")
+            preliminaryDebugLogger.debug(
+                "topK=[\(topK, privacy: .private)] confirmed=[\(confirmed, privacy: .private)]"
+            )
+        }
+        #endif
+
         // Confirm taught items as YOLO-World classes (fire-and-forget).
         for idx in includedIndices where editableSuggestions[idx].teach {
             let s = editableSuggestions[idx]
@@ -152,6 +197,121 @@ final class SuggestionReviewViewModel {
         }
 
         isConfirming = false
+    }
+
+    /// Populates `editableSuggestions` with preliminary chips from on-device
+    /// `VNClassifyImageRequest` classifications, shown while the server call
+    /// is still in-flight.
+    ///
+    /// Chips are flagged with `origin = .preliminary` so the view can render
+    /// them with "preliminary" styling. When the server response arrives, call
+    /// `applyServerSuggestions(_:)` to reconcile. See
+    /// `thoughts/shared/designs/coreml-mode-a-merge-ux.md` §2a.
+    ///
+    /// - Parameters:
+    ///   - classifications: The on-device classification results from Stage 3.
+    ///   - topK: Maximum number of chips to render. Caller chooses; production
+    ///     default is `3`. Clamped to the available classification count.
+    func loadPreliminaryClassifications(_ classifications: [ClassificationResult], topK: Int) {
+        let limit = max(0, min(topK, classifications.count))
+        originalPreliminaryTopK = Array(classifications.prefix(limit))
+        editableSuggestions = classifications.prefix(limit).enumerated().map { idx, cls in
+            EditableSuggestion(
+                id: idx,
+                included: true,
+                editedName: cls.label,
+                editedCategory: "",
+                editedQuantity: "",
+                confidence: Double(cls.confidence),
+                visionName: cls.label,
+                match: nil,
+                teach: true,
+                origin: .preliminary
+            )
+        }
+        failedIndices = []
+    }
+
+    /// Marks the chip at `index` as user-edited so subsequent merges preserve it.
+    ///
+    /// Call from the view when the user modifies any editable field on a
+    /// preliminary chip. A `.server` chip that is later edited is also valid
+    /// to mark — merge rules keep edited chips under all conditions.
+    func markEdited(index: Int) {
+        guard editableSuggestions.indices.contains(index) else { return }
+        editableSuggestions[index].origin = .edited
+    }
+
+    /// Convenience wrapper that only promotes `.preliminary` chips to `.edited`.
+    ///
+    /// `SuggestionReviewView` attaches this to `onChange` handlers on each
+    /// editable text field — calling it is cheap and avoids flipping `.server`
+    /// chips (whose identity is already authoritative).
+    func markEditedIfPreliminary(index: Int) {
+        guard editableSuggestions.indices.contains(index),
+              editableSuggestions[index].origin == .preliminary else { return }
+        editableSuggestions[index].origin = .edited
+    }
+
+    /// Reconciles the current preliminary chips with the server's suggestions.
+    ///
+    /// Behavior (from the merge-UX spike §2a):
+    /// - `.edited` chips always survive.
+    /// - `.preliminary` chips are replaced by the server's items; if a server
+    ///   item has the same normalized name, it takes over that chip slot.
+    /// - Server items whose names overlap an edited chip are skipped.
+    /// - Server-empty + no edited chips → `[]` (clean empty state; no stale
+    ///   preliminary list visible).
+    ///
+    /// - Parameter server: The server's `/ingest` suggestion response.
+    func applyServerSuggestions(_ server: [SuggestionItem]) {
+        editableSuggestions = Self.merge(preliminary: editableSuggestions, server: server)
+    }
+
+    // MARK: - Pure merge
+
+    /// Pure merge of preliminary / edited chips with a server response.
+    ///
+    /// Exposed as `static` so tests can drive it without constructing a view
+    /// model. See `thoughts/shared/designs/coreml-mode-a-merge-ux.md` §2a and
+    /// the prompt's TDD plan (REFACTOR step).
+    static func merge(
+        preliminary: [EditableSuggestion],
+        server: [SuggestionItem]
+    ) -> [EditableSuggestion] {
+        let editedChips = preliminary.filter { $0.origin == .edited }
+        let editedNames = Set(editedChips.map { Self.normalize($0.editedName) })
+
+        var result = editedChips
+        var nextId = (result.map(\.id).max() ?? -1) + 1
+
+        for item in server {
+            let key = Self.normalize(item.name)
+            if editedNames.contains(key) { continue }
+            let name = item.match?.name ?? item.name
+            let category = item.match?.category ?? item.category ?? ""
+            result.append(
+                EditableSuggestion(
+                    id: nextId,
+                    included: true,
+                    editedName: name,
+                    editedCategory: category,
+                    editedQuantity: "",
+                    confidence: item.confidence,
+                    visionName: item.name,
+                    match: item.match,
+                    teach: true,
+                    origin: .server
+                )
+            )
+            nextId += 1
+        }
+        return result
+    }
+
+    /// Case- and whitespace-insensitive key for chip-name overlap detection.
+    private static func normalize(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     /// Resumes upsert from the first previously failed index.

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -62,6 +62,11 @@ struct BinDetailView: View {
     @State private var reviewViewModel = SuggestionReviewViewModel()
     @State private var captureProxy = CaptureProxy()
     @State private var capturedPhotoData: Data?
+    /// True once preliminary on-device chips have been loaded and navigation
+    /// to `.review` happened early (Mode A). Drives how `onComplete` merges.
+    @State private var navigatedOnPreliminary = false
+    /// Top-K chips to surface as preliminary (Mode A, Phase 1).
+    private static let preliminaryTopK = 3
 
     // Model escalation
     private static let modelEscalation = ["qwen3-vl:2b", "qwen3-vl:4b", "qwen3-vl:8b"]
@@ -245,13 +250,18 @@ struct BinDetailView: View {
         AnalysisProgressView(
             viewModel: analysisViewModel,
             onComplete: { suggestions in
-                reviewViewModel.loadSuggestions(suggestions)
-                catalogingPath.append(.review)
+                if navigatedOnPreliminary {
+                    reviewViewModel.applyServerSuggestions(suggestions)
+                } else {
+                    reviewViewModel.loadSuggestions(suggestions)
+                    catalogingPath.append(.review)
+                }
             },
             onRetry: {
                 Task {
                     guard let data = capturedPhotoData else { return }
                     analysisViewModel.reset()
+                    navigatedOnPreliminary = false
                     await analysisViewModel.run(
                         jpegData: data,
                         binId: binId,
@@ -263,6 +273,7 @@ struct BinDetailView: View {
             onOverride: {
                 Task {
                     guard let data = capturedPhotoData else { return }
+                    navigatedOnPreliminary = false
                     await analysisViewModel.overrideQualityGate(
                         jpegData: data,
                         binId: binId,
@@ -270,6 +281,14 @@ struct BinDetailView: View {
                         context: modelContext
                     )
                 }
+            },
+            onPreliminaryReady: { classifications in
+                reviewViewModel.loadPreliminaryClassifications(
+                    classifications,
+                    topK: Self.preliminaryTopK
+                )
+                navigatedOnPreliminary = true
+                catalogingPath.append(.review)
             }
         )
     }
@@ -320,6 +339,7 @@ struct BinDetailView: View {
         captureProxy.action = nil
         capturedPhotoData = nil
         currentModelIndex = 0
+        navigatedOnPreliminary = false
     }
 
     // MARK: - Content

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -58,6 +58,8 @@ struct BinsListView: View {
     @State private var captureProxy = CaptureProxy()
     @State private var capturedPhotoData: Data?
     @State private var capturedBinId: String?
+    @State private var navigatedOnPreliminary = false
+    private static let preliminaryTopK = 3
 
     // Model escalation
     private static let modelEscalation = ["qwen3-vl:2b", "qwen3-vl:4b", "qwen3-vl:8b"]
@@ -193,14 +195,19 @@ struct BinsListView: View {
         AnalysisProgressView(
             viewModel: analysisViewModel,
             onComplete: { suggestions in
-                reviewViewModel.loadSuggestions(suggestions)
-                catalogingPath.append(.review)
+                if navigatedOnPreliminary {
+                    reviewViewModel.applyServerSuggestions(suggestions)
+                } else {
+                    reviewViewModel.loadSuggestions(suggestions)
+                    catalogingPath.append(.review)
+                }
             },
             onRetry: {
                 Task {
                     guard let data = capturedPhotoData,
                           let binId = capturedBinId else { return }
                     analysisViewModel.reset()
+                    navigatedOnPreliminary = false
                     await analysisViewModel.run(
                         jpegData: data,
                         binId: binId,
@@ -213,6 +220,7 @@ struct BinsListView: View {
                 Task {
                     guard let data = capturedPhotoData,
                           let binId = capturedBinId else { return }
+                    navigatedOnPreliminary = false
                     await analysisViewModel.overrideQualityGate(
                         jpegData: data,
                         binId: binId,
@@ -220,6 +228,14 @@ struct BinsListView: View {
                         context: modelContext
                     )
                 }
+            },
+            onPreliminaryReady: { classifications in
+                reviewViewModel.loadPreliminaryClassifications(
+                    classifications,
+                    topK: Self.preliminaryTopK
+                )
+                navigatedOnPreliminary = true
+                catalogingPath.append(.review)
             }
         )
     }
@@ -272,6 +288,7 @@ struct BinsListView: View {
         capturedPhotoData = nil
         capturedBinId = nil
         currentModelIndex = 0
+        navigatedOnPreliminary = false
     }
 
     // MARK: - Content

--- a/Bin Brain/Bin Brain/Views/Cataloging/AnalysisProgressView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/AnalysisProgressView.swift
@@ -29,6 +29,19 @@ struct AnalysisProgressView: View {
     /// Called when the user taps "Upload Anyway" after a `.qualityFailed` phase.
     let onOverride: () -> Void
 
+    /// Called once, when on-device `VNClassifyImageRequest` classifications
+    /// become available (Stage 3 of `ImagePipeline` succeeded) — *before* the
+    /// ~40 s server call completes. The parent uses this to render preliminary
+    /// chips in `SuggestionReviewView` and navigate early, delivering the
+    /// Mode A perceived-latency win.
+    ///
+    /// `nil` (default) preserves the pre-Mode-A blocking-progress behavior.
+    var onPreliminaryReady: (([ClassificationResult]) -> Void)?
+
+    // MARK: - Private state
+
+    @State private var didFirePreliminary = false
+
     // MARK: - Body
 
     var body: some View {
@@ -79,6 +92,16 @@ struct AnalysisProgressView: View {
             if case .complete = newPhase {
                 onComplete(viewModel.suggestions)
             }
+        }
+        .onChange(of: viewModel.preliminaryClassifications.isEmpty) { _, isEmpty in
+            guard !isEmpty,
+                  !didFirePreliminary,
+                  let onPreliminaryReady else { return }
+            didFirePreliminary = true
+            onPreliminaryReady(viewModel.preliminaryClassifications)
+        }
+        .onChange(of: viewModel.phase) { _, newPhase in
+            if case .idle = newPhase { didFirePreliminary = false }
         }
     }
 }

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -134,18 +134,28 @@ struct SuggestionReviewView: View {
 
     private func suggestionRow(at idx: Int) -> some View {
         let suggestion = viewModel.editableSuggestions[idx]
+        let isPreliminary = suggestion.origin == .preliminary
         return VStack(alignment: .leading, spacing: 8) {
+            if isPreliminary {
+                Text("Preliminary — confirming with AI")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Preliminary suggestion, confirming with AI")
+            }
             HStack {
                 Toggle(
                     isOn: $viewModel.editableSuggestions[idx].included
                 ) {
                     Text(suggestion.editedName)
                         .font(.headline)
+                        .foregroundStyle(isPreliminary ? .secondary : .primary)
                 }
 
-                Text(String(format: "%.0f%%", suggestion.confidence * 100))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if !isPreliminary {
+                    Text(String(format: "%.0f%%", suggestion.confidence * 100))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             if suggestion.isMatched {
@@ -171,13 +181,22 @@ struct SuggestionReviewView: View {
 
             TextField("Name", text: $viewModel.editableSuggestions[idx].editedName)
                 .textFieldStyle(.roundedBorder)
+                .onChange(of: viewModel.editableSuggestions[idx].editedName) { _, _ in
+                    viewModel.markEditedIfPreliminary(index: idx)
+                }
 
             TextField("Category", text: $viewModel.editableSuggestions[idx].editedCategory)
                 .textFieldStyle(.roundedBorder)
+                .onChange(of: viewModel.editableSuggestions[idx].editedCategory) { _, _ in
+                    viewModel.markEditedIfPreliminary(index: idx)
+                }
 
             TextField("Quantity", text: $viewModel.editableSuggestions[idx].editedQuantity)
                 .textFieldStyle(.roundedBorder)
                 .keyboardType(.decimalPad)
+                .onChange(of: viewModel.editableSuggestions[idx].editedQuantity) { _, _ in
+                    viewModel.markEditedIfPreliminary(index: idx)
+                }
 
             Toggle(isOn: $viewModel.editableSuggestions[idx].teach) {
                 Label("Teach for future detection", systemImage: "brain")
@@ -188,5 +207,14 @@ struct SuggestionReviewView: View {
             .tint(.green)
         }
         .padding(.vertical, 4)
+        .padding(.horizontal, isPreliminary ? 8 : 0)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                .foregroundStyle(.secondary)
+                .opacity(isPreliminary ? 1 : 0)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityHint(isPreliminary ? "Preliminary — will be confirmed by the server" : "")
     }
 }

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
@@ -1,0 +1,188 @@
+// SuggestionReviewViewModelPreliminaryTests.swift
+// Bin BrainTests
+//
+// RED tests for CoreML Mode A Phase 1 (Swift2_001_coreml_phase1_mode_a.md).
+// Covers loading on-device `VNClassifyImageRequest` results as preliminary
+// chips and merging them with the server's `[SuggestionItem]` per the
+// merge-UX spike (thoughts/shared/designs/coreml-mode-a-merge-ux.md §2a).
+
+import XCTest
+@testable import Bin_Brain
+
+@MainActor
+final class SuggestionReviewViewModelPreliminaryTests: XCTestCase {
+
+    var sut: SuggestionReviewViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SuggestionReviewViewModel()
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func classifications(_ pairs: [(String, Float)]) -> [ClassificationResult] {
+        pairs.map { ClassificationResult(label: $0.0, confidence: $0.1) }
+    }
+
+    private func serverItems(_ names: [String]) throws -> [SuggestionItem] {
+        let items = names.map { name in
+            """
+            {"item_id": null, "name": "\(name)", "category": null, "confidence": 0.9, "bins": []}
+            """
+        }
+        let json = Data("[\(items.joined(separator: ","))]".utf8)
+        return try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+    }
+
+    // MARK: - Load preliminaries
+
+    func testLoadPreliminaryClassificationsRendersTopK() {
+        let cls = classifications([("screw", 0.91), ("nail", 0.62), ("bolt", 0.33), ("washer", 0.11)])
+
+        sut.loadPreliminaryClassifications(cls, topK: 3)
+
+        XCTAssertEqual(sut.editableSuggestions.count, 3, "Should render top-K=3 preliminary chips")
+        XCTAssertEqual(sut.editableSuggestions.map(\.editedName), ["screw", "nail", "bolt"])
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.origin == .preliminary },
+                      "All chips loaded from classifications should be preliminary")
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.included },
+                      "Preliminaries default to included")
+    }
+
+    func testLoadPreliminaryWithFewerClassificationsThanTopK() {
+        let cls = classifications([("screw", 0.91)])
+
+        sut.loadPreliminaryClassifications(cls, topK: 3)
+
+        XCTAssertEqual(sut.editableSuggestions.count, 1, "Should cap at available classifications")
+    }
+
+    func testLoadEmptyPreliminariesFallsBackToEmptyState() {
+        sut.loadPreliminaryClassifications([], topK: 3)
+
+        XCTAssertTrue(sut.editableSuggestions.isEmpty,
+                      "Empty classifications must not create chips (fallback to today's behavior)")
+    }
+
+    // MARK: - Merge: server agrees
+
+    func testServerAgreesPromotesPreliminaryToServer() throws {
+        sut.loadPreliminaryClassifications(classifications([("screw", 0.91), ("nail", 0.62)]), topK: 3)
+        let server = try serverItems(["screw"])
+
+        sut.applyServerSuggestions(server)
+
+        // "screw" was in preliminary, server agrees → promoted to .server.
+        // "nail" was an untouched preliminary with no server match → dropped.
+        XCTAssertEqual(sut.editableSuggestions.count, 1, "Untouched preliminaries with no server match are dropped")
+        let chip = try XCTUnwrap(sut.editableSuggestions.first)
+        XCTAssertEqual(chip.editedName, "screw")
+        XCTAssertEqual(chip.origin, .server, "Preliminary matched by server should become .server origin")
+    }
+
+    // MARK: - Merge: server disagrees
+
+    func testServerDisagreesReplacesUntouchedPreliminaries() throws {
+        sut.loadPreliminaryClassifications(classifications([("nail", 0.71), ("washer", 0.40)]), topK: 3)
+        let server = try serverItems(["bolt", "screw"])
+
+        sut.applyServerSuggestions(server)
+
+        // All preliminaries were untouched and non-overlapping with server → dropped.
+        // Server chips appear fresh.
+        XCTAssertEqual(sut.editableSuggestions.map(\.editedName), ["bolt", "screw"])
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.origin == .server })
+    }
+
+    // MARK: - Merge: server empty
+
+    func testServerEmptyDropsUntouchedPreliminaries() {
+        sut.loadPreliminaryClassifications(classifications([("screw", 0.91)]), topK: 3)
+
+        sut.applyServerSuggestions([])
+
+        // Architect's clarification: downstream empty-state UI must see a clean [] when
+        // preliminaries are untouched and server is empty — no stale preliminary flash.
+        XCTAssertTrue(sut.editableSuggestions.isEmpty,
+                      "Server-empty + untouched preliminaries must produce [] (clean empty state)")
+    }
+
+    // MARK: - Merge: user edits survive
+
+    func testUserEditOnPreliminarySurvivesServerResponse() throws {
+        sut.loadPreliminaryClassifications(classifications([("nail", 0.71)]), topK: 3)
+
+        // Simulate user editing the preliminary chip before the server returns.
+        sut.editableSuggestions[0].editedName = "M3 screw"
+        sut.markEdited(index: 0)
+
+        let server = try serverItems(["bolt"])
+        sut.applyServerSuggestions(server)
+
+        // User's edited chip survives; server's non-overlapping chip is appended.
+        XCTAssertEqual(sut.editableSuggestions.count, 2)
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "M3 screw", "User edit preserved")
+        XCTAssertEqual(sut.editableSuggestions[0].origin, .edited)
+        XCTAssertEqual(sut.editableSuggestions[1].editedName, "bolt")
+        XCTAssertEqual(sut.editableSuggestions[1].origin, .server)
+    }
+
+    func testUserEditOverlappingServerNameDoesNotDuplicate() throws {
+        sut.loadPreliminaryClassifications(classifications([("nail", 0.71)]), topK: 3)
+        sut.editableSuggestions[0].editedName = "bolt"
+        sut.markEdited(index: 0)
+
+        let server = try serverItems(["bolt", "screw"])
+        sut.applyServerSuggestions(server)
+
+        // User edited to "bolt"; server also says "bolt". Keep user's, skip server's duplicate.
+        XCTAssertEqual(sut.editableSuggestions.count, 2, "No duplicate when user edit matches a server name")
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "bolt")
+        XCTAssertEqual(sut.editableSuggestions[0].origin, .edited)
+        XCTAssertEqual(sut.editableSuggestions[1].editedName, "screw")
+        XCTAssertEqual(sut.editableSuggestions[1].origin, .server)
+    }
+
+    // MARK: - Pure merge function
+
+    func testPureMergeFunctionIsDeterministic() throws {
+        let prelim: [EditableSuggestion] = [
+            .makePreliminary(id: 0, name: "nail", confidence: 0.71),
+            .makePreliminary(id: 1, name: "screw", confidence: 0.40)
+        ]
+        let server = try serverItems(["screw", "bolt"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: server)
+
+        // "screw" matches server → promoted. "nail" untouched + no server match → dropped.
+        // "bolt" is server-only → appended.
+        XCTAssertEqual(merged.map(\.editedName), ["screw", "bolt"])
+        XCTAssertTrue(merged.allSatisfy { $0.origin == .server })
+    }
+}
+
+// MARK: - Test helpers
+
+private extension EditableSuggestion {
+    /// Builds a preliminary `EditableSuggestion` for isolated merge-function tests.
+    static func makePreliminary(id: Int, name: String, confidence: Double) -> EditableSuggestion {
+        EditableSuggestion(
+            id: id,
+            included: true,
+            editedName: name,
+            editedCategory: "",
+            editedQuantity: "",
+            confidence: confidence,
+            visionName: name,
+            match: nil,
+            teach: true,
+            origin: .preliminary
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 Mode A** of `docs/designs/coreml-preclassification-scope.md` (`.swarm/Prompts/Swift2_001_coreml_phase1_mode_a.md`).

Surfaces the on-device `VNClassifyImageRequest` top-K (already produced by Stage 3 of `ImagePipeline`) as **preliminary editable chips** in `SuggestionReviewView` while the ~40 s Ollama call continues in the background. When the server response arrives, a pure merge function reconciles on-device preliminaries with server suggestions. User edits always win.

## Phase 0 deliverables

- **Merge-UX spike:** `thoughts/shared/designs/coreml-mode-a-merge-ux.md` (gitignored per project convention). Picked option **(a) greyed-preliminary-until-server-agrees**. Architect approved before implementation.
- **T2 (telemetry/consent):** on-device-only `os.Logger` under `#if DEBUG`, `.private` interpolation. No uploaded telemetry, no server protocol change, no `device_metadata` field leakage.
- **T3 (runtime feature flag):** explicitly out of scope (Phase 3).

## Changes

- `AnalysisViewModel`: exposes `preliminaryClassifications` the moment pipeline Stage 3 succeeds (before `.uploading`). Cleared in `reset()`.
- `AnalysisProgressView`: new `onPreliminaryReady` callback, fires exactly once per run.
- `BinDetailView` + `BinsListView`: navigate to review on preliminary; apply server suggestions on complete. Fallback preserved when classifications are empty or Stage 3 fails.
- `SuggestionReviewViewModel`: `loadPreliminaryClassifications(_:topK:)`, `applyServerSuggestions(_:)`, `markEdited` / `markEditedIfPreliminary`, and a pure `static func merge(preliminary:server:)` matching the spec's §2a table.
- `SuggestionReviewView`: dashed-border preliminary styling, 'Preliminary — confirming with AI' caption, VoiceOver hint. Text-field edits auto-promote preliminary chips to `.edited`.
- `EditableSuggestion`: new `ChipOrigin` (`.preliminary` / `.server` / `.edited`).

## Merge rules (from spike §2a)

| On-device chip | Server response | Result |
|---|---|---|
| Preliminary, untouched | Server has equivalent label | Promote to `.server`. |
| Preliminary, untouched | Server has different label | Replace with server item. |
| Preliminary, untouched | Server empty | Drop — clean `[]` empty state. |
| Preliminary, user edited | Any | Keep user's; append non-overlapping server items. |

## Tests

- 9 new unit tests in `SuggestionReviewViewModelPreliminaryTests` covering load, merge (server agrees / disagrees / empty), user-edit preservation, overlap dedup, and the pure merge function in isolation.
- Full `Bin BrainTests` suite green.

## Screenshots (three merge states)

Pending manual capture (pre-server preliminary, server agrees, server disagrees + user edit). The three states are exercised by the unit tests above.

## Must-NOT-haves (verified)

- [x] No new CoreML model bundled or downloaded.
- [x] No YOLO / MobileNetV3 / EfficientDet / custom model.
- [x] No server protocol change, no new `/ingest` fields, no `device_metadata` additions.
- [x] No uploaded telemetry.
- [x] No runtime feature flag plumbing.
- [x] No changes to `PipelineModels.ClassificationResult` shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-device waste classifications now display immediately as preliminary results while awaiting server confirmation, reducing wait times
  * Preliminary suggestions are visually marked with "Preliminary — confirming with AI" label and de-emphasized styling to indicate pending confirmation
  * User edits to preliminary suggestions are tracked and intelligently preserved when server results arrive
  * Enhanced suggestion review with improved handling of preliminary versus confirmed results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->