### PR TITLE
Swift2_014: Rejection Outcomes (iOS) — fire-and-forget /photos/{id}/outcomes after confirm

### DIFF
--- a/Bin Brain/Bin Brain/Models/APIModels.swift
+++ b/Bin Brain/Bin Brain/Models/APIModels.swift
@@ -19,6 +19,19 @@ extension JSONDecoder {
     }()
 }
 
+extension JSONEncoder {
+    /// A shared encoder configured for Bin Brain API request bodies.
+    ///
+    /// Uses ISO 8601 date encoding so `Date` fields (e.g. `shown_at` in
+    /// `PhotoSuggestionOutcome`) land on the wire in the format FastAPI's
+    /// Pydantic `datetime` validators accept without coercion.
+    static let binBrain: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+}
+
 // MARK: - Health
 
 /// The response returned by `GET /health`.
@@ -306,6 +319,84 @@ struct PhotoSuggestResponse: Decodable {
         case model
         case visionElapsedMs = "vision_elapsed_ms"
         case suggestions
+    }
+}
+
+// MARK: - Suggestion Outcomes (Swift2_014 / Dev2_017)
+
+/// One decision the user made about a VLM-suggested item on the Review screen.
+///
+/// Emitted as a fire-and-forget telemetry payload after `/confirm` succeeds.
+/// The enum's raw values match the server-side `CHECK (decision IN (...))`
+/// constraint exactly — changing them here is a wire-contract break.
+///
+/// `ignored` is part of the contract but iOS does not currently emit it: the
+/// review UI has no gesture that distinguishes "saw the suggestion, didn't
+/// touch it" from "the suggestion was never surfaced". Every non-accepted,
+/// non-edited suggestion is emitted as `rejected` until a dismiss gesture
+/// exists. See Swift2_014 deferred notes.
+struct PhotoSuggestionOutcome: Encodable, Equatable {
+    /// Decision the user made about a single presented suggestion.
+    enum Decision: String, Encodable, Equatable {
+        case accepted, rejected, edited, ignored
+    }
+
+    /// The original VLM label for the suggestion, as shown to the user.
+    let label: String
+    /// The original VLM category, if any. Preserved even when the user edits the on-screen category.
+    let category: String?
+    /// The VLM's confidence in this suggestion, `nil` if absent in the source.
+    let confidence: Double?
+    /// Normalized `[x1, y1, x2, y2]` bounding box (0–1, top-left origin), or `nil` if the VLM omitted it.
+    let bbox: [Float]?
+    /// Client-captured timestamp at which this suggestion was first presented.
+    let shownAt: Date
+    /// The user's decision for this suggestion.
+    let decision: Decision
+    /// Required when `decision == .edited`; the final label the user chose. Nil for all other decisions.
+    let editedToLabel: String?
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case category
+        case confidence
+        case bbox
+        case shownAt = "shown_at"
+        case decision
+        case editedToLabel = "edited_to_label"
+    }
+}
+
+/// The request body for `POST /photos/{photo_id}/outcomes`.
+///
+/// A batched, idempotent-per-(`photoId`, `visionModel`) payload describing
+/// every suggestion that was surfaced on the Review screen. The server replaces
+/// any prior outcomes for the pair — safe to re-fire on retry.
+struct PhotoSuggestionOutcomesRequest: Encodable, Equatable {
+    /// The VLM that produced the suggestions (from `PhotoSuggestResponse.model`).
+    let visionModel: String
+    /// Prompt revision identifier, if the server exposes it. `nil` is acceptable.
+    let promptVersion: String?
+    /// One entry per presented suggestion. Empty array is a valid no-op payload.
+    let decisions: [PhotoSuggestionOutcome]
+
+    enum CodingKeys: String, CodingKey {
+        case visionModel = "vision_model"
+        case promptVersion = "prompt_version"
+        case decisions
+    }
+}
+
+/// The response returned by `POST /photos/{photo_id}/outcomes`.
+struct PhotoSuggestionOutcomesResponse: Decodable {
+    let version: String
+    let photoId: Int
+    let outcomesRecorded: Int
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case photoId = "photo_id"
+        case outcomesRecorded = "outcomes_recorded"
     }
 }
 

--- a/Bin Brain/Bin Brain/Services/APIClient.swift
+++ b/Bin Brain/Bin Brain/Services/APIClient.swift
@@ -255,6 +255,35 @@ final class APIClient {
         )
     }
 
+    /// Posts the per-suggestion decision list for a photo as fire-and-forget telemetry.
+    ///
+    /// The server persists one row per decision to `photo_suggestion_outcomes`,
+    /// idempotently per (`photoId`, `request.visionModel`) — safe to retry.
+    /// This call is NOT on the confirm critical path; callers should wrap it
+    /// in a detached `Task` and swallow errors. See Swift2_014 / Dev2_017.
+    ///
+    /// - Parameters:
+    ///   - photoId: The photo ID returned by a prior `ingest` call.
+    ///   - request: The batched outcomes request (`visionModel`, optional
+    ///     `promptVersion`, and the full per-suggestion decision list).
+    /// - Throws: `APIClientError.missingAPIKey` / `.invalidURL` /
+    ///   `.unexpectedStatusCode`, or any underlying `URLError`. Callers are
+    ///   expected to log and discard — outcomes failure must never surface.
+    @discardableResult
+    func postPhotoSuggestionOutcomes(
+        photoId: Int,
+        request: PhotoSuggestionOutcomesRequest
+    ) async throws -> PhotoSuggestionOutcomesResponse {
+        let body = try JSONEncoder.binBrain.encode(request)
+        return try await self.request(
+            path: "/photos/\(String(photoId).urlPathComponentEncoded)/outcomes",
+            method: "POST",
+            body: body,
+            contentType: "application/json",
+            timeout: 10
+        )
+    }
+
     /// Creates or upserts an item in the catalogue, optionally linking it to a bin.
     ///
     /// Fields with `nil` values are omitted from the multipart request body.

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -402,6 +402,7 @@ final class AnalysisViewModel {
         suggestions = []
         preliminaryClassifications = []
         lastPhotoId = nil
+        lastVisionModel = nil
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         lastUploadedPhotoData = nil

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -62,6 +62,13 @@ final class AnalysisViewModel {
     /// The photo ID from the last successful ingest; `nil` until ingest completes.
     private(set) var lastPhotoId: Int?
 
+    /// The VLM that produced the most recent suggestion list, sourced from
+    /// `PhotoSuggestResponse.model`. Consumed by parent views (BinsListView,
+    /// BinDetailView) when handing off to `SuggestionReviewViewModel` so
+    /// Swift2_014 outcomes telemetry knows which model produced the
+    /// decisions being reported. `nil` until a suggest response lands.
+    private(set) var lastVisionModel: String?
+
     /// The last quality gate failure, if any. Set when `phase == .qualityFailed`.
     private(set) var lastQualityFailure: QualityGateFailure?
 
@@ -238,6 +245,7 @@ final class AnalysisViewModel {
         do {
             let suggestResponse = try await suggestTask.value
             suggestions = suggestResponse.suggestions
+            lastVisionModel = suggestResponse.model
             phase = .complete
 
             // Clean up the pending analysis entry on success.
@@ -340,6 +348,7 @@ final class AnalysisViewModel {
         do {
             let suggestResponse = try await apiClient.suggest(photoId: photoId)
             suggestions = suggestResponse.suggestions
+            lastVisionModel = suggestResponse.model
             phase = .complete
         } catch {
             phase = .failed(error.localizedDescription)
@@ -380,6 +389,7 @@ final class AnalysisViewModel {
         do {
             let response = try await apiClient.suggest(photoId: photoId)
             suggestions = response.suggestions
+            lastVisionModel = response.model
             phase = .complete
         } catch {
             phase = .failed(error.localizedDescription)

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -237,6 +237,11 @@ final class SuggestionReviewViewModel {
         visionModel: String? = nil,
         promptVersion: String? = nil
     ) {
+        // Fresh server-suggestion landing ⇒ fresh review session. Drop any
+        // prior `shownAt` so stale stamps from an earlier photo don't leak
+        // into this session's outcomes telemetry (ultrareview bug_003 — the
+        // VM outlives a cataloging flow via @State in the parent view).
+        shownAt = nil
         editableSuggestions = suggestions.enumerated().map { idx, item in
             let name = item.match?.name ?? item.name
             let category = item.match?.category ?? item.category ?? ""
@@ -373,6 +378,11 @@ final class SuggestionReviewViewModel {
     ///   - topK: Maximum number of chips to render. Caller chooses; production
     ///     default is `3`. Clamped to the available classification count.
     func loadPreliminaryClassifications(_ classifications: [ClassificationResult], topK: Int) {
+        // Fresh session (on-device preliminary chips arrive BEFORE server
+        // suggestions). Reset `shownAt` here so the subsequent
+        // `applyServerSuggestions` stamp isn't shadowed by a leftover from
+        // an earlier cataloging flow (ultrareview bug_003).
+        shownAt = nil
         let limit = max(0, min(topK, classifications.count))
         originalPreliminaryTopK = Array(classifications.prefix(limit))
         editableSuggestions = classifications.prefix(limit).enumerated().map { idx, cls in
@@ -556,7 +566,14 @@ final class SuggestionReviewViewModel {
             let confirmed = confirmedIds.contains(item.id)
             let finalLabel = item.editedName.trimmingCharacters(in: .whitespacesAndNewlines)
             let originalLabel = item.visionName
-            let wasEdited = confirmed && !finalLabel.isEmpty && finalLabel != originalLabel
+            // Edit-detection baseline is the value `editedName` was PREFILLED
+            // with — which is `match.name` when a catalogue match exists,
+            // NOT `visionName`. Comparing against `visionName` alone would
+            // false-flag every catalogue-matched but untouched confirmation
+            // as `.edited` (poisoning the training signal Swift2_014 exists
+            // to collect — see ultrareview bug_001).
+            let prefilledLabel = item.match?.name ?? item.visionName
+            let wasEdited = confirmed && !finalLabel.isEmpty && finalLabel != prefilledLabel
 
             let decision: PhotoSuggestionOutcome.Decision
             let editedTo: String?

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -237,11 +237,13 @@ final class SuggestionReviewViewModel {
         visionModel: String? = nil,
         promptVersion: String? = nil
     ) {
-        // Fresh server-suggestion landing ⇒ fresh review session. Drop any
-        // prior `shownAt` so stale stamps from an earlier photo don't leak
-        // into this session's outcomes telemetry (ultrareview bug_003 — the
-        // VM outlives a cataloging flow via @State in the parent view).
-        shownAt = nil
+        // Fresh server-suggestion landing ⇒ fresh review session. Drop ALL
+        // prior outcomes context so stale values from an earlier photo don't
+        // leak into this session's telemetry. Production callers pass
+        // photoId + visionModel every time, but clearing defensively here
+        // guarantees a reused VM cannot attach new decisions to old context.
+        // (ultrareview bug_003 + CodeRabbit defense-in-depth follow-up.)
+        resetOutcomesContext()
         editableSuggestions = suggestions.enumerated().map { idx, item in
             let name = item.match?.name ?? item.name
             let category = item.match?.category ?? item.category ?? ""
@@ -379,10 +381,11 @@ final class SuggestionReviewViewModel {
     ///     default is `3`. Clamped to the available classification count.
     func loadPreliminaryClassifications(_ classifications: [ClassificationResult], topK: Int) {
         // Fresh session (on-device preliminary chips arrive BEFORE server
-        // suggestions). Reset `shownAt` here so the subsequent
-        // `applyServerSuggestions` stamp isn't shadowed by a leftover from
-        // an earlier cataloging flow (ultrareview bug_003).
-        shownAt = nil
+        // suggestions). Reset ALL outcomes context here so the subsequent
+        // `applyServerSuggestions` lands on a clean slate — otherwise a
+        // reused VM carries the prior session's photoId/visionModel forward
+        // if the new applyServerSuggestions caller were to omit them.
+        resetOutcomesContext()
         let limit = max(0, min(topK, classifications.count))
         originalPreliminaryTopK = Array(classifications.prefix(limit))
         editableSuggestions = classifications.prefix(limit).enumerated().map { idx, cls in
@@ -458,6 +461,18 @@ final class SuggestionReviewViewModel {
             visionModel: visionModel,
             promptVersion: promptVersion
         )
+    }
+
+    /// Clears all outcomes-telemetry context to a clean "not-yet-ready"
+    /// state. Called at fresh-session entry points (`loadSuggestions`,
+    /// `loadPreliminaryClassifications`) so a reused `@State`-held VM
+    /// cannot carry stale (photoId, visionModel, promptVersion, shownAt)
+    /// from a prior cataloging flow into the new session's outcomes POST.
+    private func resetOutcomesContext() {
+        photoId = 0
+        visionModel = nil
+        promptVersion = nil
+        shownAt = nil
     }
 
     /// Applies any supplied outcomes-telemetry context values and stamps

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -60,6 +60,12 @@ struct EditableSuggestion: Identifiable {
     var teach: Bool
     /// Chip provenance — drives preliminary styling and merge rules.
     var origin: ChipOrigin = .server
+    /// Category from the original server suggestion, preserved even after the
+    /// user edits `editedCategory`. Used by Swift2_014 to emit accurate
+    /// `PhotoSuggestionOutcome.category` — the original VLM signal is what the
+    /// server wants for training, not the user's replacement. Nil for chips
+    /// that did not come from a server suggestion (preliminary CoreML chips).
+    let originalCategory: String?
 }
 
 // MARK: - SuggestionReviewViewModel
@@ -148,6 +154,30 @@ final class SuggestionReviewViewModel {
     /// treats empty as "not yet ready" and aborts the call.
     var binId: String = ""
 
+    // MARK: - Swift2_014 Outcomes State
+
+    /// Photo identifier under review, threaded from `AnalysisViewModel.lastPhotoId`.
+    /// Required for `POST /photos/{id}/outcomes`. Zero is a "not-yet-assigned"
+    /// sentinel — the outcomes fire-and-forget guard short-circuits in that state.
+    var photoId: Int = 0
+
+    /// The VLM that produced the current suggestion list. Captured from
+    /// `PhotoSuggestResponse.model` via `loadSuggestions(_:photoId:visionModel:promptVersion:)`
+    /// or `applyServerSuggestions(_:photoId:visionModel:promptVersion:)`. The outcomes
+    /// fire guard requires a non-nil value.
+    private(set) var visionModel: String?
+
+    /// Prompt revision identifier. Today the server does not emit
+    /// `prompt_version` on `/suggest`; this stays nil until a matching server
+    /// follow-up (flagged from Swift2_014). Nil is a valid server-side value.
+    private(set) var promptVersion: String?
+
+    /// Wall-clock time the first non-empty server suggestion list landed.
+    /// Every `PhotoSuggestionOutcome.shownAt` inherits this value. Stamped
+    /// once per review session; preserved across subsequent merges and
+    /// retries so confirm+retry cycles report a stable presentation time.
+    private(set) var shownAt: Date?
+
     /// Decoded image derived from `photoData`. Populated off the main actor
     /// via `Task.detached` and published back through `publish(image:generation:)`.
     /// Views bind directly to this instead of decoding in the view body.
@@ -186,14 +216,27 @@ final class SuggestionReviewViewModel {
     ///
     /// When a suggestion has a catalogue `match`, the matched item's name and
     /// category are used as defaults (since the catalogue entry is more accurate
-    /// than the raw vision label). The original vision name is preserved in
-    /// `visionName` for reference.
+    /// than the raw vision label). The original vision name and category are
+    /// preserved in `visionName` and `originalCategory` for reference and for
+    /// Swift2_014 outcome telemetry.
     ///
     /// Each item starts with `included = true`. Calling this method clears
     /// any previous `failedIndices`.
     ///
-    /// - Parameter suggestions: The suggestion items returned by vision inference.
-    func loadSuggestions(_ suggestions: [SuggestionItem]) {
+    /// - Parameters:
+    ///   - suggestions: The suggestion items returned by vision inference.
+    ///   - photoId: Optional photo ID to thread through for outcomes telemetry.
+    ///     Omit (or pass `nil`) to leave the current value unchanged.
+    ///   - visionModel: Optional VLM identifier from `PhotoSuggestResponse.model`.
+    ///     Omit to leave the current value unchanged.
+    ///   - promptVersion: Optional prompt revision identifier. Kept nil today
+    ///     (server follow-up pending).
+    func loadSuggestions(
+        _ suggestions: [SuggestionItem],
+        photoId: Int? = nil,
+        visionModel: String? = nil,
+        promptVersion: String? = nil
+    ) {
         editableSuggestions = suggestions.enumerated().map { idx, item in
             let name = item.match?.name ?? item.name
             let category = item.match?.category ?? item.category ?? ""
@@ -207,10 +250,16 @@ final class SuggestionReviewViewModel {
                 visionName: item.name,
                 match: item.match,
                 bbox: item.bbox,
-                teach: true
+                teach: true,
+                originalCategory: item.category
             )
         }
         failedIndices = []
+        applyOutcomesContext(
+            photoId: photoId,
+            visionModel: visionModel,
+            promptVersion: promptVersion
+        )
     }
 
     // MARK: - Actions
@@ -334,7 +383,8 @@ final class SuggestionReviewViewModel {
                 match: nil,
                 bbox: nil,
                 teach: true,
-                origin: .preliminary
+                origin: .preliminary,
+                originalCategory: nil
             )
         }
         failedIndices = []
@@ -377,9 +427,43 @@ final class SuggestionReviewViewModel {
     /// - Server-empty + no edited chips → `[]` (clean empty state; no stale
     ///   preliminary list visible).
     ///
-    /// - Parameter server: The server's `/ingest` suggestion response.
-    func applyServerSuggestions(_ server: [SuggestionItem]) {
+    /// - Parameters:
+    ///   - server: The server's `/ingest` suggestion response.
+    ///   - photoId: Optional photo ID threaded through for outcomes telemetry.
+    ///   - visionModel: Optional VLM identifier from `PhotoSuggestResponse.model`.
+    ///   - promptVersion: Optional prompt revision identifier (server follow-up pending).
+    func applyServerSuggestions(
+        _ server: [SuggestionItem],
+        photoId: Int? = nil,
+        visionModel: String? = nil,
+        promptVersion: String? = nil
+    ) {
         editableSuggestions = Self.merge(preliminary: editableSuggestions, server: server)
+        applyOutcomesContext(
+            photoId: photoId,
+            visionModel: visionModel,
+            promptVersion: promptVersion
+        )
+    }
+
+    /// Applies any supplied outcomes-telemetry context values and stamps
+    /// `shownAt` on the first non-empty suggestion landing.
+    ///
+    /// `nil` parameters are no-ops, so existing callers that don't pass context
+    /// preserve any state set through another path. `shownAt` is stamped at most
+    /// once per review session — subsequent merges don't reset it, so confirm +
+    /// retryRemaining cycles report a stable presentation time.
+    private func applyOutcomesContext(
+        photoId: Int?,
+        visionModel: String?,
+        promptVersion: String?
+    ) {
+        if let photoId { self.photoId = photoId }
+        if let visionModel { self.visionModel = visionModel }
+        if let promptVersion { self.promptVersion = promptVersion }
+        if shownAt == nil, !editableSuggestions.isEmpty {
+            shownAt = Date()
+        }
     }
 
     // MARK: - Pure merge
@@ -416,7 +500,8 @@ final class SuggestionReviewViewModel {
                     match: item.match,
                     bbox: item.bbox,
                     teach: true,
-                    origin: .server
+                    origin: .server,
+                    originalCategory: item.category
                 )
             )
             nextId += 1
@@ -428,6 +513,77 @@ final class SuggestionReviewViewModel {
     private static func normalize(_ name: String) -> String {
         name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
+
+    // MARK: - Swift2_014 Outcomes Building
+
+    /// Builds per-suggestion decision telemetry from the presented list.
+    ///
+    /// Pure function — exposed as `static` so tests can drive the classification
+    /// logic without constructing a view model, network stack, or Task scheduler.
+    ///
+    /// Classification rules (Phase 2a):
+    /// - Item in `confirmedIds` with unchanged label → `.accepted`.
+    /// - Item in `confirmedIds` with `editedName != visionName` → `.edited`
+    ///   (carries `editedToLabel`).
+    /// - Item NOT in `confirmedIds` → `.rejected`.
+    /// - `.ignored` is never emitted — deferred until the UI has an explicit
+    ///   dismiss gesture that distinguishes "saw but didn't act" from "toggled
+    ///   off".
+    ///
+    /// Defensive: an `.edited` decision with a missing/empty `editedToLabel`
+    /// would trip the server's Pydantic validator (422). Such entries are
+    /// dropped from the output rather than emitted, per the fire-and-forget
+    /// contract — never throw from telemetry.
+    ///
+    /// - Parameters:
+    ///   - shownAt: Client-captured timestamp at which the suggestion list
+    ///     was first presented. Every outcome inherits this value.
+    ///   - editable: The presented suggestion list as the user last saw it.
+    ///   - confirmedIds: IDs of items that made it through upsert + associate.
+    ///     Every other item is classified `.rejected`.
+    /// - Returns: One `PhotoSuggestionOutcome` per presented item, minus any
+    ///   defensively-dropped broken `.edited` entries.
+    static func buildOutcomes(
+        shownAt: Date,
+        editable: [EditableSuggestion],
+        confirmedIds: Set<Int>
+    ) -> [PhotoSuggestionOutcome] {
+        editable.compactMap { item in
+            let confirmed = confirmedIds.contains(item.id)
+            let finalLabel = item.editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let originalLabel = item.visionName
+            let wasEdited = confirmed && !finalLabel.isEmpty && finalLabel != originalLabel
+
+            let decision: PhotoSuggestionOutcome.Decision
+            let editedTo: String?
+            if wasEdited {
+                decision = .edited
+                editedTo = finalLabel
+            } else if confirmed {
+                decision = .accepted
+                editedTo = nil
+            } else {
+                decision = .rejected
+                editedTo = nil
+            }
+
+            if decision == .edited, (editedTo ?? "").isEmpty {
+                logger.error("[OUTCOMES] dropping edited decision with empty label for '\(originalLabel, privacy: .private)'")
+                return nil
+            }
+
+            return PhotoSuggestionOutcome(
+                label: originalLabel,
+                category: item.originalCategory,
+                confidence: item.confidence,
+                bbox: item.bbox,
+                shownAt: shownAt,
+                decision: decision,
+                editedToLabel: editedTo
+            )
+        }
+    }
+
 
     /// Resumes upsert from the first previously failed index.
     ///

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -352,6 +352,10 @@ final class SuggestionReviewViewModel {
             }
         }
 
+        // Swift2_014 — telemetry fires only on confirm-success; failures here
+        // MUST NOT surface (fire-and-forget detached Task swallows errors).
+        fireOutcomesIfReady(apiClient: apiClient)
+
         isConfirming = false
     }
 
@@ -584,6 +588,38 @@ final class SuggestionReviewViewModel {
         }
     }
 
+    /// Fires `POST /photos/{id}/outcomes` in a detached Task when the VM has
+    /// everything needed. Silent no-op otherwise — outcomes are best-effort.
+    ///
+    /// Must be called ONLY from a confirm-success path (no failedIndices,
+    /// upsert+associate loop completed). Errors are logged, never surfaced.
+    private func fireOutcomesIfReady(apiClient: APIClient) {
+        guard photoId > 0,
+              let visionModel,
+              let shownAt,
+              !editableSuggestions.isEmpty else {
+            return
+        }
+        let confirmedIds = Set(editableSuggestions.filter { $0.included }.map(\.id))
+        let decisions = Self.buildOutcomes(
+            shownAt: shownAt,
+            editable: editableSuggestions,
+            confirmedIds: confirmedIds
+        )
+        let request = PhotoSuggestionOutcomesRequest(
+            visionModel: visionModel,
+            promptVersion: promptVersion,
+            decisions: decisions
+        )
+        let pid = photoId
+        Task { [apiClient, pid, request] in
+            do {
+                _ = try await apiClient.postPhotoSuggestionOutcomes(photoId: pid, request: request)
+            } catch {
+                logger.error("[OUTCOMES] fire-and-forget post failed: \(error.localizedDescription, privacy: .private)")
+            }
+        }
+    }
 
     /// Resumes upsert from the first previously failed index.
     ///
@@ -622,6 +658,9 @@ final class SuggestionReviewViewModel {
                 return
             }
         }
+        // Swift2_014 — retry success path also fires outcomes (server is
+        // idempotent per (photoId, visionModel), so re-firing is safe).
+        fireOutcomesIfReady(apiClient: apiClient)
         isConfirming = false
     }
 

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -284,9 +284,17 @@ struct BinDetailView: View {
             onComplete: { suggestions in
                 reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
                 if navigatedOnPreliminary {
-                    reviewViewModel.applyServerSuggestions(suggestions)
+                    reviewViewModel.applyServerSuggestions(
+                        suggestions,
+                        photoId: analysisViewModel.lastPhotoId,
+                        visionModel: analysisViewModel.lastVisionModel
+                    )
                 } else {
-                    reviewViewModel.loadSuggestions(suggestions)
+                    reviewViewModel.loadSuggestions(
+                        suggestions,
+                        photoId: analysisViewModel.lastPhotoId,
+                        visionModel: analysisViewModel.lastVisionModel
+                    )
                     catalogingPath.append(.review)
                 }
             },
@@ -342,7 +350,11 @@ struct BinDetailView: View {
         .onChange(of: analysisViewModel.phase) { _, newPhase in
             guard case .complete = newPhase, navigatedOnPreliminary else { return }
             reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
-            reviewViewModel.applyServerSuggestions(analysisViewModel.suggestions)
+            reviewViewModel.applyServerSuggestions(
+                analysisViewModel.suggestions,
+                photoId: analysisViewModel.lastPhotoId,
+                visionModel: analysisViewModel.lastVisionModel
+            )
         }
     }
 

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -219,9 +219,17 @@ struct BinsListView: View {
             onComplete: { suggestions in
                 reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
                 if navigatedOnPreliminary {
-                    reviewViewModel.applyServerSuggestions(suggestions)
+                    reviewViewModel.applyServerSuggestions(
+                        suggestions,
+                        photoId: analysisViewModel.lastPhotoId,
+                        visionModel: analysisViewModel.lastVisionModel
+                    )
                 } else {
-                    reviewViewModel.loadSuggestions(suggestions)
+                    reviewViewModel.loadSuggestions(
+                        suggestions,
+                        photoId: analysisViewModel.lastPhotoId,
+                        visionModel: analysisViewModel.lastVisionModel
+                    )
                     catalogingPath.append(.review)
                 }
             },
@@ -279,7 +287,11 @@ struct BinsListView: View {
         .onChange(of: analysisViewModel.phase) { _, newPhase in
             guard case .complete = newPhase, navigatedOnPreliminary else { return }
             reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
-            reviewViewModel.applyServerSuggestions(analysisViewModel.suggestions)
+            reviewViewModel.applyServerSuggestions(
+                analysisViewModel.suggestions,
+                photoId: analysisViewModel.lastPhotoId,
+                visionModel: analysisViewModel.lastVisionModel
+            )
         }
     }
 

--- a/Bin Brain/Bin BrainTests/AnalysisViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/AnalysisViewModelTests.swift
@@ -218,6 +218,32 @@ final class AnalysisViewModelTests: XCTestCase {
         XCTAssertTrue(sut.suggestions.isEmpty, "reset() should clear suggestions")
     }
 
+    // MARK: - Regression — Swift2_014: reset() clears lastVisionModel
+
+    /// `lastVisionModel` is threaded into `SuggestionReviewViewModel` for
+    /// outcomes telemetry (Swift2_014). If `reset()` leaves it intact, a
+    /// subsequent cataloging flow whose `/suggest` response somehow lacks
+    /// the `model` field (or that never reaches `suggest`) would carry
+    /// forward the prior session's VLM string and attach it to the new
+    /// photo's outcomes POST — mislabeling which model produced what.
+    func testResetClearsLastVisionModel() async {
+        let client = makeMockAPIClient { [self] request in
+            if request.url?.path.contains("/suggest") == true {
+                return (makeAnalysisMockResponse(statusCode: 200), suggestSuccessJSON)
+            }
+            return (makeAnalysisMockResponse(statusCode: 200), ingestSuccessJSON)
+        }
+
+        await sut.run(jpegData: Data("fake-jpeg".utf8), binId: "BIN-0001", apiClient: client)
+        XCTAssertEqual(sut.lastVisionModel, "test-model",
+                       "lastVisionModel should be populated from /suggest response.model")
+
+        sut.reset()
+
+        XCTAssertNil(sut.lastVisionModel,
+                     "reset() must clear lastVisionModel — stale model IDs would mislabel future outcomes telemetry")
+    }
+
     // MARK: - Test 6: suggestions are cleared after reset
 
     func testSuggestionsAreEmptyAfterReset() async {

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -1,0 +1,396 @@
+// PhotoSuggestionOutcomesTests.swift
+// Bin BrainTests
+//
+// Swift2_014 — Rejection Outcomes (iOS).
+// Covers the pure `buildOutcomes` decision builder AND the fire-and-forget
+// POST /photos/{id}/outcomes integration surface on SuggestionReviewViewModel.
+//
+// Idiom matches SuggestionReviewViewModelTests (URLProtocol-based mock). The
+// mock name is file-local to avoid symbol collisions across test bundles.
+
+import XCTest
+import UIKit
+@testable import Bin_Brain
+
+// MARK: - OutcomesMockURLProtocol
+
+/// URLProtocol subclass that intercepts requests for PhotoSuggestionOutcomesTests.
+///
+/// Distinct class name from `SuggestionReviewMockURLProtocol` and
+/// `AnalysisMockURLProtocol` to avoid link-time collisions in the shared test
+/// bundle. Handlers return (status, body) synchronously.
+final class OutcomesMockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = OutcomesMockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - URLRequest body helper
+
+private extension URLRequest {
+    var outcomesBodyData: Data? {
+        if let data = httpBody { return data }
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 65_536
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(&buffer, maxLength: bufferSize)
+            guard bytesRead > 0 else { break }
+            data.append(contentsOf: buffer.prefix(bytesRead))
+        }
+        return data
+    }
+}
+
+// MARK: - PhotoSuggestionOutcomesTests
+
+@MainActor
+final class PhotoSuggestionOutcomesTests: XCTestCase {
+
+    var sut: SuggestionReviewViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SuggestionReviewViewModel()
+    }
+
+    override func tearDown() async throws {
+        OutcomesMockURLProtocol.requestHandler = nil
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private let fixedShownAt = Date(timeIntervalSince1970: 1_744_920_000) // 2026-04-17T20:00:00Z
+
+    private func makeEditable(
+        id: Int,
+        name: String,
+        included: Bool = true,
+        editedName: String? = nil,
+        category: String? = "fastener",
+        confidence: Double = 0.9,
+        bbox: [Float]? = [0.1, 0.2, 0.3, 0.4]
+    ) -> EditableSuggestion {
+        EditableSuggestion(
+            id: id,
+            included: included,
+            editedName: editedName ?? name,
+            editedCategory: category ?? "",
+            editedQuantity: "",
+            confidence: confidence,
+            visionName: name,
+            match: nil,
+            bbox: bbox,
+            teach: true,
+            origin: .server,
+            originalCategory: category
+        )
+    }
+
+    private func makeSuggestionsJSON() throws -> [SuggestionItem] {
+        let json = Data("""
+        [
+            {"item_id": null, "name": "hex bolt", "category": "fastener", "confidence": 0.91, "bins": [], "bbox": [0.12, 0.34, 0.40, 0.68]},
+            {"item_id": null, "name": "lamp base", "category": null, "confidence": 0.74, "bins": []}
+        ]
+        """.utf8)
+        return try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+    }
+
+    private func makeMockAPIClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        OutcomesMockURLProtocol.requestHandler = handler
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [OutcomesMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func mockResponse(statusCode: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private var upsertSuccessJSON: Data {
+        Data(#"{"version":"1","item_id":101,"fingerprint":"hex_bolt|fastener","name":"hex bolt","category":"fastener"}"#.utf8)
+    }
+
+    private var associateSuccessJSON: Data {
+        Data(#"{"ok":true,"bin_id":"BIN-0001","item_id":101}"#.utf8)
+    }
+
+    private var confirmClassSuccessJSON: Data {
+        Data(#"{"version":"1","class_name":"hex bolt","added":true,"active_class_count":47,"reload_triggered":true}"#.utf8)
+    }
+
+    private var outcomesSuccessJSON: Data {
+        Data(#"{"version":"1","photo_id":42,"outcomes_recorded":2}"#.utf8)
+    }
+
+    // MARK: - 1. accepted decisions for confirmed selections
+
+    func testBuildOutcomes_acceptedDecisionsProducedForConfirmedSelections() {
+        let editable = [
+            makeEditable(id: 0, name: "hex bolt", confidence: 0.91, bbox: [0.12, 0.34, 0.40, 0.68])
+        ]
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: editable,
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes.count, 1)
+        let o = outcomes[0]
+        XCTAssertEqual(o.decision, .accepted)
+        XCTAssertEqual(o.label, "hex bolt")
+        XCTAssertEqual(o.category, "fastener")
+        XCTAssertEqual(o.confidence, 0.91)
+        XCTAssertEqual(o.bbox, [0.12, 0.34, 0.40, 0.68])
+        XCTAssertEqual(o.shownAt, fixedShownAt)
+        XCTAssertNil(o.editedToLabel)
+    }
+
+    // MARK: - 2. rejected for unselected suggestions
+
+    func testBuildOutcomes_rejectedForUnselectedSuggestions() {
+        let editable = [
+            makeEditable(id: 0, name: "hex bolt"),
+            makeEditable(id: 1, name: "lamp base"),
+            makeEditable(id: 2, name: "plastic gear")
+        ]
+        // User confirmed only id 0 (e.g. toggled off 1 and 2 before confirm).
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: editable,
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes.count, 3)
+        let decisionsByLabel = Dictionary(uniqueKeysWithValues: outcomes.map { ($0.label, $0.decision) })
+        XCTAssertEqual(decisionsByLabel["hex bolt"], .accepted)
+        XCTAssertEqual(decisionsByLabel["lamp base"], .rejected)
+        XCTAssertEqual(decisionsByLabel["plastic gear"], .rejected)
+        // Rejected items carry no edited_to_label.
+        for o in outcomes where o.decision == .rejected {
+            XCTAssertNil(o.editedToLabel, "rejected decisions must not carry edited_to_label")
+        }
+    }
+
+    // MARK: - 3. edited decision when label changed
+
+    func testBuildOutcomes_editedDecisionWhenLabelChanged() {
+        let editable = [
+            makeEditable(id: 0, name: "screw", editedName: "M5 bolt")
+        ]
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: editable,
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes.count, 1)
+        let o = outcomes[0]
+        XCTAssertEqual(o.decision, .edited)
+        XCTAssertEqual(o.label, "screw", "label must be the original VLM suggestion (vision name)")
+        XCTAssertEqual(o.editedToLabel, "M5 bolt", "edited_to_label must be the final user-chosen label")
+    }
+
+    // MARK: - 4. shownAt propagates from VM timestamp
+
+    func testBuildOutcomes_shownAtPropagatesFromVMTimestamp() {
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let editable = [
+            makeEditable(id: 0, name: "hex bolt"),
+            makeEditable(id: 1, name: "lamp base", included: false)
+        ]
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: stamp,
+            editable: editable,
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes.count, 2)
+        XCTAssertTrue(outcomes.allSatisfy { $0.shownAt == stamp },
+                      "every outcome must inherit the VM-captured shownAt")
+    }
+
+    // MARK: - 5. bbox pass-through
+
+    func testBuildOutcomes_bboxPassesThroughWhenPresentNilWhenAbsent() {
+        let editable = [
+            makeEditable(id: 0, name: "hex bolt", bbox: [0.1, 0.2, 0.3, 0.4]),
+            makeEditable(id: 1, name: "lamp base", bbox: nil)
+        ]
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: editable,
+            confirmedIds: [0, 1]
+        )
+        let boxByLabel = Dictionary(uniqueKeysWithValues: outcomes.map { ($0.label, $0.bbox) })
+        XCTAssertEqual(boxByLabel["hex bolt"], [0.1, 0.2, 0.3, 0.4])
+        XCTAssertNil(boxByLabel["lamp base"] ?? nil, "absent bbox must round-trip as nil")
+    }
+
+    // MARK: - 6. confirm success fires outcomes POST with expected payload
+
+    func testConfirmSuccess_firesOutcomesPostWithExpectedPayload() async throws {
+        let suggestions = try makeSuggestionsJSON()
+        sut.loadSuggestions(suggestions, photoId: 42, visionModel: "qwen3p6-plus", promptVersion: nil)
+        // Toggle off "lamp base" so we have one accepted, one rejected.
+        sut.editableSuggestions[1].included = false
+
+        let expectation = XCTestExpectation(description: "POST /photos/42/outcomes is invoked")
+        let capturedBody = CapturedBody()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                capturedBody.data = request.outcomesBodyData
+                expectation.fulfill()
+                return (mockResponse(statusCode: 200, for: request), outcomesSuccessJSON)
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody.data, "outcomes request body must be captured")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any],
+                                 "outcomes body must be JSON object")
+        XCTAssertEqual(json["vision_model"] as? String, "qwen3p6-plus")
+        let decisions = try XCTUnwrap(json["decisions"] as? [[String: Any]])
+        XCTAssertEqual(decisions.count, 2, "both presented suggestions must be reported")
+        let decisionKinds = Set(decisions.compactMap { $0["decision"] as? String })
+        XCTAssertEqual(decisionKinds, ["accepted", "rejected"],
+                       "one accepted + one rejected when user confirms 1 of 2")
+        XCTAssertTrue(decisions.allSatisfy { $0["shown_at"] != nil },
+                      "each decision must carry shown_at")
+    }
+
+    // MARK: - 7. outcomes failure does not surface or set confirmationErrorMessage
+
+    func testConfirmSuccess_outcomesFailureDoesNotSurfaceOrSetError() async throws {
+        let suggestions = try makeSuggestionsJSON()
+        sut.loadSuggestions(suggestions, photoId: 42, visionModel: "qwen3p6-plus", promptVersion: nil)
+
+        let outcomesCalled = XCTestExpectation(description: "outcomes POST attempted")
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                outcomesCalled.fulfill()
+                return (mockResponse(statusCode: 500, for: request), Data())
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await fulfillment(of: [outcomesCalled], timeout: 2.0)
+        // Give the detached Task one extra yield to process the 500 and reach its catch.
+        await Task.yield()
+
+        XCTAssertNil(sut.confirmationErrorMessage,
+                     "outcomes 500 must NOT surface via confirmationErrorMessage")
+        XCTAssertTrue(sut.failedIndices.isEmpty,
+                      "outcomes failure must not taint confirm's success state")
+    }
+
+    // MARK: - 8. confirm failure does NOT fire outcomes
+
+    func testConfirmFailure_doesNotFireOutcomesPost() async throws {
+        let suggestions = try makeSuggestionsJSON()
+        sut.loadSuggestions(suggestions, photoId: 42, visionModel: "qwen3p6-plus", promptVersion: nil)
+
+        let outcomesCallCount = CallCounter()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                outcomesCallCount.increment()
+                return (mockResponse(statusCode: 200, for: request), outcomesSuccessJSON)
+            }
+            // First upsert fails → confirm aborts before teach loop or outcomes.
+            return (mockResponse(statusCode: 500, for: request), Data())
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        // Give any stray background tasks time to fire (there should be none).
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(sut.failedIndices.isEmpty, "confirm failed — failedIndices must be non-empty")
+        XCTAssertEqual(outcomesCallCount.value, 0,
+                       "outcomes POST MUST NOT fire when confirm fails")
+    }
+
+    // MARK: - 9. empty suggestions → empty decisions, no fire
+
+    func testBuildOutcomes_emptySuggestionsListProducesEmptyDecisions() {
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: [],
+            confirmedIds: []
+        )
+        XCTAssertTrue(outcomes.isEmpty, "no presented suggestions → no decisions")
+    }
+}
+
+// MARK: - Test helpers
+
+/// Thread-safe box to capture request bodies from the URLProtocol handler.
+///
+/// `@MainActor` tests stream data from the handler thread; wrapping in a
+/// reference type lets the handler's escaping closure write while the test
+/// body reads after `fulfillment(of:)` returns.
+private final class CapturedBody: @unchecked Sendable {
+    var data: Data?
+}
+
+/// Atomic counter for mock invocation counts.
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        _value += 1
+    }
+}

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -22,8 +22,8 @@ import UIKit
 final class OutcomesMockURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         guard let handler = OutcomesMockURLProtocol.requestHandler else {
@@ -459,6 +459,31 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
                              "loadSuggestions must RESET shownAt on a fresh session — stale stamps corrupt training telemetry")
     }
 
+    /// Defense-in-depth: a caller that omits photoId/visionModel on a
+    /// subsequent `loadSuggestions` (e.g. an ad-hoc test path or a future
+    /// refactor) must not inherit the prior session's values. The
+    /// `resetOutcomesContext` call at the top of loadSuggestions zeros
+    /// everything out; `applyOutcomesContext` then only re-sets params the
+    /// new caller explicitly passed. (CodeRabbit PR#19 defensive follow-up.)
+    func testLoadSuggestionsWithoutContextParamsClearsPriorSessionValues() throws {
+        let suggestions = try makeSuggestionsJSON()
+
+        // Session 1: full context.
+        sut.loadSuggestions(suggestions, photoId: 99, visionModel: "vlm-a", promptVersion: "v2")
+        XCTAssertEqual(sut.photoId, 99)
+        XCTAssertEqual(sut.visionModel, "vlm-a")
+        XCTAssertEqual(sut.promptVersion, "v2")
+
+        // Session 2: caller omits context (photoId/visionModel/promptVersion default to nil).
+        sut.loadSuggestions(suggestions)
+        XCTAssertEqual(sut.photoId, 0,
+                       "photoId must be zeroed on fresh session — else fireOutcomes would post to the wrong photo")
+        XCTAssertNil(sut.visionModel,
+                     "visionModel must be cleared on fresh session — else telemetry mislabels which model produced the suggestions")
+        XCTAssertNil(sut.promptVersion,
+                     "promptVersion must be cleared on fresh session")
+    }
+
     /// Preliminary chips also mark a fresh session: the CoreML path runs
     /// BEFORE the server responds, and the subsequent `applyServerSuggestions`
     /// is what stamps `shownAt`. `loadPreliminaryClassifications` must clear
@@ -505,9 +530,21 @@ private enum SuggestionMatchFixture {
 ///
 /// `@MainActor` tests stream data from the handler thread; wrapping in a
 /// reference type lets the handler's escaping closure write while the test
-/// body reads after `fulfillment(of:)` returns.
+/// body reads after `fulfillment(of:)` returns. Mirrors `CallCounter`'s
+/// `NSLock` pattern so TSAN has nothing to complain about.
 private final class CapturedBody: @unchecked Sendable {
-    var data: Data?
+    private let lock = NSLock()
+    private var _data: Data?
+    var data: Data? {
+        get {
+            lock.lock(); defer { lock.unlock() }
+            return _data
+        }
+        set {
+            lock.lock(); defer { lock.unlock() }
+            _data = newValue
+        }
+    }
 }
 
 /// Atomic counter for mock invocation counts.

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -83,7 +83,7 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    private let fixedShownAt = Date(timeIntervalSince1970: 1_744_920_000) // 2026-04-17T20:00:00Z
+    private let fixedShownAt = Date(timeIntervalSince1970: 1_776_456_000) // 2026-04-17T20:00:00Z
 
     private func makeEditable(
         id: Int,
@@ -368,6 +368,135 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
         )
         XCTAssertTrue(outcomes.isEmpty, "no presented suggestions → no decisions")
     }
+
+    // MARK: - 10. Regression — catalogue-matched untouched → .accepted (ultrareview bug_001)
+
+    /// When a server suggestion carries a `SuggestionMatch`, `loadSuggestions`
+    /// pre-fills `editedName` from `match.name` (not `visionName`). A naïve
+    /// `editedName != visionName` edit-detection would false-flag every
+    /// matched-but-untouched confirmation as `.edited`, poisoning the training
+    /// signal. `buildOutcomes` must compare against the pre-fill baseline
+    /// (`match.name ?? visionName`) so untouched matched items stay `.accepted`.
+    func testBuildOutcomes_catalogueMatchedUntouchedItemClassifiedAsAccepted() {
+        let match = SuggestionMatchFixture.hexNutM3
+        let matched = EditableSuggestion(
+            id: 0,
+            included: true,
+            editedName: match.name,       // pre-filled from match.name by loadSuggestions
+            editedCategory: match.category ?? "",
+            editedQuantity: "",
+            confidence: 0.9,
+            visionName: "hex nut",         // raw VLM label — diverges from editedName at load time
+            match: match,
+            bbox: nil,
+            teach: true,
+            origin: .server,
+            originalCategory: "fastener"
+        )
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: [matched],
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes.count, 1)
+        XCTAssertEqual(outcomes[0].decision, .accepted,
+                       "matched, user-untouched item must be .accepted — comparing editedName to visionName alone would wrongly emit .edited")
+        XCTAssertNil(outcomes[0].editedToLabel)
+        XCTAssertEqual(outcomes[0].label, "hex nut",
+                       "label must be the raw VLM signal (visionName), not the catalogue match name")
+    }
+
+    /// And confirm the real-edit path still fires when the user overrides a
+    /// matched pre-fill — the baseline shift must not suppress genuine edits.
+    func testBuildOutcomes_catalogueMatchedThenUserEditedStillEmitsEdited() {
+        let match = SuggestionMatchFixture.hexNutM3
+        let edited = EditableSuggestion(
+            id: 0,
+            included: true,
+            editedName: "M3 stainless nut", // user overrode the match prefill
+            editedCategory: "fastener",
+            editedQuantity: "",
+            confidence: 0.9,
+            visionName: "hex nut",
+            match: match,
+            bbox: nil,
+            teach: true,
+            origin: .edited,
+            originalCategory: "fastener"
+        )
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: [edited],
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes[0].decision, .edited)
+        XCTAssertEqual(outcomes[0].label, "hex nut")
+        XCTAssertEqual(outcomes[0].editedToLabel, "M3 stainless nut")
+    }
+
+    // MARK: - 11. Regression — shownAt restamps on fresh session (ultrareview bug_003)
+
+    /// `SuggestionReviewViewModel` is held as `@State` in the parent views and
+    /// survives across cataloging flows. Without an explicit reset, `shownAt`
+    /// would be stamped exactly once per VM lifetime — so the second review
+    /// session on a given screen would POST outcomes with the previous
+    /// session's wall-clock time, corrupting the telemetry. `loadSuggestions`
+    /// (the fresh-session entry point) must reset `shownAt` so each session
+    /// gets its own stamp.
+    func testLoadSuggestionsResetsShownAtAcrossSessions() async throws {
+        let suggestions = try makeSuggestionsJSON()
+
+        sut.loadSuggestions(suggestions, photoId: 10, visionModel: "vlm-a")
+        let firstShownAt = try XCTUnwrap(sut.shownAt, "first session must stamp shownAt")
+
+        // Nudge wall clock forward so the ordering check is robust.
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        sut.loadSuggestions(suggestions, photoId: 11, visionModel: "vlm-a")
+        let secondShownAt = try XCTUnwrap(sut.shownAt, "second session must stamp shownAt")
+
+        XCTAssertGreaterThan(secondShownAt, firstShownAt,
+                             "loadSuggestions must RESET shownAt on a fresh session — stale stamps corrupt training telemetry")
+    }
+
+    /// Preliminary chips also mark a fresh session: the CoreML path runs
+    /// BEFORE the server responds, and the subsequent `applyServerSuggestions`
+    /// is what stamps `shownAt`. `loadPreliminaryClassifications` must clear
+    /// any leftover stamp so the server-landing stamp is the one that lands.
+    func testLoadPreliminaryClassificationsResetsShownAtAcrossSessions() async throws {
+        let suggestions = try makeSuggestionsJSON()
+
+        // Session 1: server path stamps shownAt.
+        sut.loadSuggestions(suggestions, photoId: 10, visionModel: "vlm-a")
+        let firstShownAt = try XCTUnwrap(sut.shownAt)
+
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Session 2: preliminary chips land FIRST — must clear the prior stamp.
+        sut.loadPreliminaryClassifications([], topK: 0)
+        XCTAssertNil(sut.shownAt,
+                     "loadPreliminaryClassifications must clear shownAt so applyServerSuggestions re-stamps on server arrival")
+
+        // Subsequent server arrival stamps fresh.
+        sut.applyServerSuggestions(suggestions, photoId: 11, visionModel: "vlm-a")
+        let secondShownAt = try XCTUnwrap(sut.shownAt)
+        XCTAssertGreaterThan(secondShownAt, firstShownAt)
+    }
+}
+
+// MARK: - Fixtures
+
+private enum SuggestionMatchFixture {
+    /// Shared `SuggestionMatch` for catalogue-match regression tests.
+    /// Name differs from the VLM label so `editedName != visionName` at load
+    /// time — the exact condition that exposed ultrareview bug_001.
+    static let hexNutM3 = SuggestionMatch(
+        itemId: 1,
+        name: "Hex Nut M3",
+        category: "fastener",
+        score: 0.95,
+        bins: []
+    )
 }
 
 // MARK: - Test helpers

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
@@ -183,7 +183,8 @@ private extension EditableSuggestion {
             match: nil,
             bbox: nil,
             teach: true,
-            origin: .preliminary
+            origin: .preliminary,
+            originalCategory: nil
         )
     }
 }


### PR DESCRIPTION
# Swift2_014 — Rejection Outcomes (iOS)

iOS half of **Phase 2 of the Data Capture plan**, matching server-side Dev2_017 (merged as `944de2b`). After a successful `/confirm`, the app now fires a single fire-and-forget `POST /photos/{id}/outcomes` carrying the decision-annotated list of every suggestion that was shown on the Review screen.

Closes the single highest-ML-value data gap: suggestions the user saw and rejected / edited are no longer lost to the void.

## Behavior

- After `/confirm` **succeeds**, a detached `Task` posts the full decision list to `/photos/{id}/outcomes`. Failures never surface (no toast, no error state — `os_log` only).
- After `retryRemaining()` **succeeds**, the same fire-and-forget path runs (the server is idempotent per `(photo_id, vision_model)`, so re-firing after a partial-then-retry is safe).
- On confirm **failure**, outcomes are NOT fired (`failedIndices` non-empty → short-circuit).
- The Review UI is **unchanged** — this is telemetry only. No new buttons, no confirmation dialogs, no extra waits. Swift2_013 error-surfacing invariants preserved.

## Commits (6)

| SHA | Title |
|---|---|
| `4415e50` | `feat(api-models): add PhotoSuggestionOutcome + request/response shapes` |
| `c9b6822` | `feat(api-client): postPhotoSuggestionOutcomes (POST /photos/{id}/outcomes)` |
| `0a0ab07` | `feat(suggestion-review): capture shownAt + visionModel + per-suggestion decisions` |
| `baf72cb` | `feat(suggestion-review): fire outcomes telemetry after successful confirm` |
| `12e2391` | `test(suggestion-review): cover decision building, fire-and-forget semantics, failure isolation` |
| `07cda92` | `fix(suggestion-review): address ultrareview findings (match baseline + shownAt reset)` |

## Decision Rules

Each presented suggestion maps to exactly one `PhotoSuggestionOutcome`:

| Condition | Decision |
|---|---|
| In `confirmedIds`, `editedName == match.name ?? visionName` (pre-fill unchanged) | `.accepted` |
| In `confirmedIds`, `editedName` differs from pre-fill baseline and is non-empty | `.edited` (with `editedToLabel`) |
| NOT in `confirmedIds` (toggled off before confirm) | `.rejected` |

`.ignored` is part of the wire contract but **not emitted in Phase 2a** — see scope deltas below.

## Phase 2a Scope Deltas (intentional, flagged for follow-up)

1. **`prompt_version` is sent as `null`.** Server `/suggest` doesn't currently echo `prompt_version` on its response. iOS will plumb it through once the server emits it (likely Dev2_018 or Dev2_016b patch).
2. **`ignored` decision is never emitted.** The review UI has no gesture that distinguishes "saw the suggestion, didn't touch it" from "toggled off before confirming" — all non-accepted, non-edited items are emitted as `.rejected`. Deferred until a UI dismiss gesture exists.
3. **No offline outcomes persistence.** Outcomes are best-effort fire-and-forget. A dropped outcome on a bad network is acceptable — the user's confirm is not affected.

## Ultrareview Fixes (commit `07cda92`)

Ran `/ultrareview` during development; 3 findings, all addressed before push:

- **bug_001 (normal)** — Catalogue-matched untouched items were mis-classified as `.edited` because `loadSuggestions` pre-fills `editedName` from `match.name` while `visionName` stays at `item.name`. `buildOutcomes` now compares against the prefill baseline (`match.name ?? visionName`), so untouched matched confirmations correctly emit `.accepted`. +2 regression tests.
- **bug_003 (normal)** — `shownAt` leaked across review sessions because `SuggestionReviewViewModel` is held as `@State` in the parent views and outlives individual cataloging flows. Cleared at top of `loadSuggestions` and `loadPreliminaryClassifications` (the two fresh-session entry points); `applyServerSuggestions` still preserves the stamp across preliminary→server merges within a single session. +2 regression tests.
- **bug_004 (nit)** — Test fixture comment claimed 2026-04-17 but the epoch constant decoded to 2025-04-17. Bumped to `1_776_456_000` for a genuine 2026 stamp.

## Test Results (iPhone 17 simulator)

- **12/12** `PhotoSuggestionOutcomesTests` **PASS** (9 from prompt + 3 regression)
- **56/56** `SuggestionReviewViewModel*` **PASS** — Swift2_013 error-surface tests specifically verified green
- **No new warnings** with the no-`-quiet` build policy

### 3 pre-existing failures unrelated to this PR (SECURITY: please skip)

These failed on `main` before this branch existed. None are in code this PR touches. Flagging explicitly so you don't chase ghosts:

| Test | Why it fails (pre-existing) |
|---|---|
| `APIClientTests.testAssociateItemSendsMultipartWithSpecRequiredFieldNames` | Test asserts multipart body, but `APIClient.associateItem` sends `application/json` (drift between test expectation and implementation — pre-existing) |
| `APIClientTests.testAssociateItemOmitsOptionalFieldsWhenNil` | Same class of drift as above |
| `MetadataExtractorsTests.testFilterClassificationsAppliesThresholdAndLimit` | Asserts `classificationConfidenceThreshold == 0.1` and `classificationMaxResults == 5` — constant-check test for values I did not touch |

## Architecture Notes

- `SuggestionReviewViewModel.buildOutcomes` is a `static` **pure function** — tests drive it directly without a VM instance or network stack. Classification logic is unit-testable in isolation from fire-and-forget plumbing.
- `fireOutcomesIfReady` guard-checks `photoId > 0 && visionModel != nil && shownAt != nil && !editableSuggestions.isEmpty` before spawning the Task — silent no-op when context is incomplete.
- `PhotoSuggestionOutcome.Decision` raw values match the server `CHECK (decision IN (...))` constraint exactly; changing them is a wire break.
- `JSONEncoder.binBrain` mirrors the existing `JSONDecoder.binBrain` with `.iso8601` date encoding so `shown_at` lands as a string that FastAPI's `datetime` validators accept without coercion.

## Server Contract

Authoritative contract lives in `../binbrain/binbrain/.swarm/Prompts/Dev2_017_rejection_outcomes_server.md` (merged in `944de2b`). Endpoint is live in production; ready for real end-to-end smoke.

## Constraints observed

- No server repo changes.
- No force unwraps in new Swift code.
- No suppression of warnings; no `-quiet` builds.
- No changes to `/confirm` path error handling (Swift2_013 intact).
- No toasts / alerts on outcomes failures — `os_log` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic telemetry collection for photo suggestion reviews, capturing user feedback decisions to improve recommendation accuracy.

* **Refactor**
  * Enhanced suggestion workflow to maintain original category data alongside user edits and track suggestion context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->