### PR TITLE
Swift2_015: prompt_version plumbing — drop Phase 2a null hack (Phase 2b-α)

### DIFF
--- a/Bin Brain/Bin Brain/Models/APIModels.swift
+++ b/Bin Brain/Bin Brain/Models/APIModels.swift
@@ -306,10 +306,17 @@ struct SuggestionItem: Decodable {
 }
 
 /// The response returned by `GET /photos/{photo_id}/suggest`.
+///
+/// `promptVersion` mirrors the server's `prompt_version` field introduced by
+/// binbrain PRs #22/#23 — the live constant on fresh calls, or the historical
+/// stamp on cache hits (may differ from the live value after a prompt bump).
+/// Nil when the server did not echo the field (older server build or a future
+/// case where the value is genuinely absent).
 struct PhotoSuggestResponse: Decodable {
     let version: String
     let photoId: Int
     let model: String
+    let promptVersion: String?
     let visionElapsedMs: Int
     let suggestions: [SuggestionItem]
 
@@ -317,6 +324,7 @@ struct PhotoSuggestResponse: Decodable {
         case version
         case photoId = "photo_id"
         case model
+        case promptVersion = "prompt_version"
         case visionElapsedMs = "vision_elapsed_ms"
         case suggestions
     }

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -69,6 +69,16 @@ final class AnalysisViewModel {
     /// decisions being reported. `nil` until a suggest response lands.
     private(set) var lastVisionModel: String?
 
+    /// The prompt revision identifier echoed by the most recent
+    /// `/suggest` response (`PhotoSuggestResponse.promptVersion`). Threaded
+    /// into `SuggestionReviewViewModel` so outcomes telemetry records the
+    /// exact prompt version under which the user's decisions were made.
+    /// `nil` until a suggest response lands OR when the server omitted the
+    /// field (cache hit from before prompt_version was exposed, or any
+    /// future case where the value is genuinely absent). iOS must forward
+    /// nil unchanged — never synthesize a client-side value.
+    private(set) var lastPromptVersion: String?
+
     /// The last quality gate failure, if any. Set when `phase == .qualityFailed`.
     private(set) var lastQualityFailure: QualityGateFailure?
 
@@ -246,6 +256,7 @@ final class AnalysisViewModel {
             let suggestResponse = try await suggestTask.value
             suggestions = suggestResponse.suggestions
             lastVisionModel = suggestResponse.model
+            lastPromptVersion = suggestResponse.promptVersion
             phase = .complete
 
             // Clean up the pending analysis entry on success.
@@ -349,6 +360,7 @@ final class AnalysisViewModel {
             let suggestResponse = try await apiClient.suggest(photoId: photoId)
             suggestions = suggestResponse.suggestions
             lastVisionModel = suggestResponse.model
+            lastPromptVersion = suggestResponse.promptVersion
             phase = .complete
         } catch {
             phase = .failed(error.localizedDescription)
@@ -390,6 +402,7 @@ final class AnalysisViewModel {
             let response = try await apiClient.suggest(photoId: photoId)
             suggestions = response.suggestions
             lastVisionModel = response.model
+            lastPromptVersion = response.promptVersion
             phase = .complete
         } catch {
             phase = .failed(error.localizedDescription)
@@ -403,6 +416,7 @@ final class AnalysisViewModel {
         preliminaryClassifications = []
         lastPhotoId = nil
         lastVisionModel = nil
+        lastPromptVersion = nil
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         lastUploadedPhotoData = nil

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -167,9 +167,14 @@ final class SuggestionReviewViewModel {
     /// fire guard requires a non-nil value.
     private(set) var visionModel: String?
 
-    /// Prompt revision identifier. Today the server does not emit
-    /// `prompt_version` on `/suggest`; this stays nil until a matching server
-    /// follow-up (flagged from Swift2_014). Nil is a valid server-side value.
+    /// Prompt revision identifier echoed by the server on `/suggest`
+    /// (binbrain PRs #22/#23). Threaded in via
+    /// `loadSuggestions(...,promptVersion:)` or
+    /// `applyServerSuggestions(...,promptVersion:)` and emitted on the
+    /// outcomes POST so the training signal records the exact prompt
+    /// under which the user's decisions were made. Nil is a valid
+    /// server-side value (pre-bump cache hit, or an older server build).
+    /// iOS must forward nil unchanged — never synthesize a client value.
     private(set) var promptVersion: String?
 
     /// Wall-clock time the first non-empty server suggestion list landed.

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -287,13 +287,15 @@ struct BinDetailView: View {
                     reviewViewModel.applyServerSuggestions(
                         suggestions,
                         photoId: analysisViewModel.lastPhotoId,
-                        visionModel: analysisViewModel.lastVisionModel
+                        visionModel: analysisViewModel.lastVisionModel,
+                        promptVersion: analysisViewModel.lastPromptVersion
                     )
                 } else {
                     reviewViewModel.loadSuggestions(
                         suggestions,
                         photoId: analysisViewModel.lastPhotoId,
-                        visionModel: analysisViewModel.lastVisionModel
+                        visionModel: analysisViewModel.lastVisionModel,
+                        promptVersion: analysisViewModel.lastPromptVersion
                     )
                     catalogingPath.append(.review)
                 }
@@ -353,7 +355,8 @@ struct BinDetailView: View {
             reviewViewModel.applyServerSuggestions(
                 analysisViewModel.suggestions,
                 photoId: analysisViewModel.lastPhotoId,
-                visionModel: analysisViewModel.lastVisionModel
+                visionModel: analysisViewModel.lastVisionModel,
+                promptVersion: analysisViewModel.lastPromptVersion
             )
         }
     }

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -222,13 +222,15 @@ struct BinsListView: View {
                     reviewViewModel.applyServerSuggestions(
                         suggestions,
                         photoId: analysisViewModel.lastPhotoId,
-                        visionModel: analysisViewModel.lastVisionModel
+                        visionModel: analysisViewModel.lastVisionModel,
+                        promptVersion: analysisViewModel.lastPromptVersion
                     )
                 } else {
                     reviewViewModel.loadSuggestions(
                         suggestions,
                         photoId: analysisViewModel.lastPhotoId,
-                        visionModel: analysisViewModel.lastVisionModel
+                        visionModel: analysisViewModel.lastVisionModel,
+                        promptVersion: analysisViewModel.lastPromptVersion
                     )
                     catalogingPath.append(.review)
                 }
@@ -290,7 +292,8 @@ struct BinsListView: View {
             reviewViewModel.applyServerSuggestions(
                 analysisViewModel.suggestions,
                 photoId: analysisViewModel.lastPhotoId,
-                visionModel: analysisViewModel.lastVisionModel
+                visionModel: analysisViewModel.lastVisionModel,
+                promptVersion: analysisViewModel.lastPromptVersion
             )
         }
     }

--- a/Bin Brain/Bin BrainTests/APIModelsTests.swift
+++ b/Bin Brain/Bin BrainTests/APIModelsTests.swift
@@ -343,6 +343,59 @@ final class APIModelsTests: XCTestCase {
         XCTAssertEqual(response.suggestions[2].bins, ["B-10", "B-42"])
     }
 
+    // MARK: - Swift2_015 — PhotoSuggestResponse.promptVersion decoding
+
+    /// Server PR #22 exposes `prompt_version` on `/suggest` responses.
+    /// A fresh call echoes the live `PROMPT_VERSION` constant (e.g. "v2").
+    /// The iOS decoder must capture it so outcomes telemetry can report the
+    /// exact prompt under which the user's decisions were made.
+    func testPhotoSuggestResponseDecodesPromptVersionWhenPresent() throws {
+        let json = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": "v2",
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let response = try decode(PhotoSuggestResponse.self, from: json)
+        XCTAssertEqual(response.promptVersion, "v2",
+                       "prompt_version echoed by /suggest must be decoded into PhotoSuggestResponse.promptVersion")
+    }
+
+    /// Pre-bump cache hits echo a historically stamped value that may be
+    /// `null`. Older server builds (pre-PR #22) omit the field entirely.
+    /// Both shapes must decode to `nil` — iOS must never synthesize a value.
+    func testPhotoSuggestResponseDecodesPromptVersionAsNilWhenAbsentOrNull() throws {
+        let explicitNullJSON = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": null,
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let missingKeyJSON = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let fromNull = try decode(PhotoSuggestResponse.self, from: explicitNullJSON)
+        XCTAssertNil(fromNull.promptVersion,
+                     "explicit null prompt_version must decode as nil — never a client-synthesized default")
+        let fromMissing = try decode(PhotoSuggestResponse.self, from: missingKeyJSON)
+        XCTAssertNil(fromMissing.promptVersion,
+                     "absent prompt_version must decode as nil (backward compat with pre-PR#22 server builds)")
+    }
+
     // MARK: - Test 9: Invalid JSON throws on missing required field
 
     func testDecodingBinSummaryThrowsOnMissingRequiredField() {

--- a/Bin Brain/Bin BrainTests/AnalysisViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/AnalysisViewModelTests.swift
@@ -132,6 +132,24 @@ final class AnalysisViewModelTests: XCTestCase {
         """.utf8)
     }
 
+    /// Swift2_015 — suggest response that echoes the server's live
+    /// `prompt_version = "v2"` (PR #22). Used to verify the VM captures
+    /// the value into `lastPromptVersion` for downstream outcomes telemetry.
+    private var suggestSuccessJSONWithPromptVersion: Data {
+        Data("""
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "test-model",
+            "prompt_version": "v2",
+            "vision_elapsed_ms": 1200,
+            "suggestions": [
+                {"item_id": null, "name": "Widget", "category": "Hardware", "confidence": 0.92, "bins": ["BIN-0001"]}
+            ]
+        }
+        """.utf8)
+    }
+
     private var serverErrorJSON: Data {
         Data("""
         {"version": "1", "error": {"code": "server_error", "message": "Internal server error"}}
@@ -242,6 +260,64 @@ final class AnalysisViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.lastVisionModel,
                      "reset() must clear lastVisionModel — stale model IDs would mislabel future outcomes telemetry")
+    }
+
+    // MARK: - Swift2_015 — lastPromptVersion capture & reset
+
+    /// The `/suggest` endpoint echoes `prompt_version` (binbrain PR #22).
+    /// AnalysisViewModel must capture it on successful completion so parent
+    /// views can thread it into `SuggestionReviewViewModel` for outcomes
+    /// telemetry. Without this capture, outcomes POST bodies would forever
+    /// carry `prompt_version: null` (the Phase 2a hack Swift2_015 removes).
+    func testRunCapturesLastPromptVersionFromSuggest() async {
+        let client = makeMockAPIClient { [self] request in
+            if request.url?.path.contains("/suggest") == true {
+                return (makeAnalysisMockResponse(statusCode: 200), suggestSuccessJSONWithPromptVersion)
+            }
+            return (makeAnalysisMockResponse(statusCode: 200), ingestSuccessJSON)
+        }
+
+        await sut.run(jpegData: Data("fake-jpeg".utf8), binId: "BIN-0001", apiClient: client)
+
+        XCTAssertEqual(sut.lastPromptVersion, "v2",
+                       "lastPromptVersion must be populated from /suggest response.prompt_version")
+    }
+
+    /// When the server omits `prompt_version` (older build or genuine
+    /// absence), iOS must forward nil — never synthesize a client-side value.
+    func testRunLeavesLastPromptVersionNilWhenSuggestOmitsField() async {
+        let client = makeMockAPIClient { [self] request in
+            if request.url?.path.contains("/suggest") == true {
+                return (makeAnalysisMockResponse(statusCode: 200), suggestSuccessJSON)
+            }
+            return (makeAnalysisMockResponse(statusCode: 200), ingestSuccessJSON)
+        }
+
+        await sut.run(jpegData: Data("fake-jpeg".utf8), binId: "BIN-0001", apiClient: client)
+
+        XCTAssertNil(sut.lastPromptVersion,
+                     "lastPromptVersion must stay nil when the server did not echo prompt_version")
+    }
+
+    /// Same leak risk as `lastVisionModel` — a stale prompt_version carried
+    /// across cataloging flows would mislabel which prompt produced the
+    /// user's decisions. `reset()` must clear it.
+    func testResetClearsLastPromptVersion() async {
+        let client = makeMockAPIClient { [self] request in
+            if request.url?.path.contains("/suggest") == true {
+                return (makeAnalysisMockResponse(statusCode: 200), suggestSuccessJSONWithPromptVersion)
+            }
+            return (makeAnalysisMockResponse(statusCode: 200), ingestSuccessJSON)
+        }
+
+        await sut.run(jpegData: Data("fake-jpeg".utf8), binId: "BIN-0001", apiClient: client)
+        XCTAssertEqual(sut.lastPromptVersion, "v2",
+                       "precondition — lastPromptVersion populated after a successful run")
+
+        sut.reset()
+
+        XCTAssertNil(sut.lastPromptVersion,
+                     "reset() must clear lastPromptVersion — stale prompt IDs would mislabel future outcomes telemetry")
     }
 
     // MARK: - Test 6: suggestions are cleared after reset

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -484,6 +484,130 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
                      "promptVersion must be cleared on fresh session")
     }
 
+    // MARK: - Swift2_015 — prompt_version plumbing end-to-end
+
+    /// When the /suggest response echoes `prompt_version: "v2"` (server
+    /// PRs #22/#23), `SuggestionReviewViewModel` captures it via
+    /// `loadSuggestions(..., promptVersion: "v2")` and forwards the exact
+    /// value onto every outcomes POST fired from that session.
+    func testOutcomesRequestBodyCarriesPromptVersionWhenServerEchoedValue() async throws {
+        let suggestions = try makeSuggestionsJSON()
+        sut.loadSuggestions(suggestions, photoId: 42, visionModel: "qwen3p6-plus", promptVersion: "v2")
+
+        let expectation = XCTestExpectation(description: "POST /photos/42/outcomes is invoked")
+        let capturedBody = CapturedBody()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                capturedBody.data = request.outcomesBodyData
+                expectation.fulfill()
+                return (mockResponse(statusCode: 200, for: request), outcomesSuccessJSON)
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody.data)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["prompt_version"] as? String, "v2",
+                       "outcomes POST must echo the server-captured prompt_version at the request level")
+    }
+
+    /// Pre-bump cache hits (or older server builds) produce a nil
+    /// prompt_version. iOS must forward nil unchanged — never synthesize a
+    /// client-side default.
+    func testOutcomesRequestBodyCarriesNullPromptVersionWhenServerReturnedNone() async throws {
+        let suggestions = try makeSuggestionsJSON()
+        sut.loadSuggestions(suggestions, photoId: 42, visionModel: "qwen3p6-plus", promptVersion: nil)
+
+        let expectation = XCTestExpectation(description: "POST /photos/42/outcomes is invoked")
+        let capturedBody = CapturedBody()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                capturedBody.data = request.outcomesBodyData
+                expectation.fulfill()
+                return (mockResponse(statusCode: 200, for: request), outcomesSuccessJSON)
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody.data)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        // `JSONEncoder` emits nil optionals as absent keys, so the field is
+        // either missing or explicitly NSNull. Either shape is acceptable;
+        // what matters is that NO synthesized client value leaks.
+        let rawValue = json["prompt_version"]
+        if let stringValue = rawValue as? String {
+            XCTFail("prompt_version must not be a synthesized string when server returned none, got \(stringValue)")
+        }
+        // Either NSNull or nil (absent key) is correct.
+        XCTAssertTrue(rawValue == nil || rawValue is NSNull,
+                      "prompt_version must be absent or null when the server did not echo a value")
+    }
+
+    /// Defense-in-depth: a review session that captured prompt_version "v2"
+    /// must not leak that value into a SUBSEQUENT session on the same VM
+    /// whose /suggest returned nil. `resetOutcomesContext` already handles
+    /// this for the state field; this test locks in the end-to-end contract
+    /// so future refactors can't silently reintroduce the leak.
+    func testPriorSessionsPromptVersionDoesNotLeakWhenNewSessionReturnsNull() async throws {
+        let suggestions = try makeSuggestionsJSON()
+
+        // Session 1: /suggest echoed "v2" — VM captures it.
+        sut.loadSuggestions(suggestions, photoId: 10, visionModel: "vlm-a", promptVersion: "v2")
+        XCTAssertEqual(sut.promptVersion, "v2", "precondition — session 1 captures v2")
+
+        // Session 2: fresh /suggest, no prompt_version echoed.
+        sut.loadSuggestions(suggestions, photoId: 11, visionModel: "vlm-a", promptVersion: nil)
+
+        let expectation = XCTestExpectation(description: "POST /photos/11/outcomes fired")
+        let capturedBody = CapturedBody()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/outcomes") {
+                capturedBody.data = request.outcomesBodyData
+                expectation.fulfill()
+                return (mockResponse(statusCode: 200, for: request), outcomesSuccessJSON)
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody.data)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let rawValue = json["prompt_version"]
+        XCTAssertFalse(rawValue as? String == "v2",
+                       "session 2 outcomes must NOT carry session 1's prompt_version — telemetry mislabel risk")
+        XCTAssertTrue(rawValue == nil || rawValue is NSNull,
+                      "session 2 POST must carry null prompt_version (matches what the server echoed)")
+    }
+
     /// Preliminary chips also mark a fresh session: the CoreML path runs
     /// BEFORE the server responds, and the subsequent `applyServerSuggestions`
     /// is what stamps `shownAt`. `loadPreliminaryClassifications` must clear


### PR DESCRIPTION
## Swift2_015 — prompt_version plumbing (Phase 2b-α)

Closes the Phase 2a scope delta #1 from Swift2_014 (PR #19). The server's `/suggest` response now echoes `prompt_version`; this drops the `prompt_version: null` hack in the outcomes payload and sends the value the server emitted for that review session.

Unblocked by:
- **binbrain PR #22** — telemetry + floor around `PROMPT_VERSION`
- **binbrain PR #23** — characterization test + SSoT docs

Both merged today.

## Wire flow

```
/suggest response
  │  prompt_version: "v2"   (fresh call; live PROMPT_VERSION)
  │  prompt_version: null   (pre-bump cache hit; older server build)
  ▼
PhotoSuggestResponse.promptVersion   ← added to CodingKeys (backward-compatible)
  ▼
AnalysisViewModel.lastPromptVersion  ← assigned in run / overrideQualityGate /
  ▼                                    reSuggest; cleared by reset()
BinsListView / BinDetailView         ← forwards to loadSuggestions(...,
  ▼                                    promptVersion:) and
  ▼                                    applyServerSuggestions(..., promptVersion:)
SuggestionReviewViewModel.promptVersion
  ▼
PhotoSuggestionOutcomesRequest.promptVersion (batch-level; one value per POST)
```

`buildOutcomes` per-outcome struct is unchanged — per architect confirmation, the server stores `prompt_version` at the batch level (`SuggestionOutcomesRequest.prompt_version` in `api/app/routes/photos.py`) and the repository stamps the single request-level value onto every row. Duplicating it per-decision would add redundancy the server neither reads nor expects.

## Decision table update

| Field | Before Swift2_015 | After Swift2_015 |
|---|---|---|
| `PhotoSuggestionOutcomesRequest.vision_model` | server-echoed | server-echoed (unchanged) |
| `PhotoSuggestionOutcomesRequest.prompt_version` | hard-coded `null` | server-echoed (nil if server omitted) |
| per-decision fields (`label`, `category`, `confidence`, `bbox`, `shown_at`, `decision`, `edited_to_label`) | captured | captured (unchanged) |

iOS never synthesizes a client-side default — if the server returned nil, iOS forwards nil unchanged.

## Changes

**Decode:**
- `APIModels.swift` — `PhotoSuggestResponse` gains `promptVersion: String?` with `prompt_version` CodingKey.

**Capture:**
- `AnalysisViewModel.swift` — new `private(set) var lastPromptVersion: String?`; mirror `lastVisionModel` across `run` / `overrideQualityGate` / `reSuggest` / `reset()`.

**Forward:**
- `BinsListView.swift` + `BinDetailView.swift` — pass `analysisViewModel.lastPromptVersion` through `loadSuggestions(...)` and `applyServerSuggestions(...)` at every handoff point (onComplete, onChange phase observers).

**Docs:**
- `SuggestionReviewViewModel.swift` — refresh the stale `promptVersion` doc comment that said "the server does not emit prompt_version on /suggest".

## Tests

New, passing:
- `APIModelsTests.testPhotoSuggestResponseDecodesPromptVersionWhenPresent`
- `APIModelsTests.testPhotoSuggestResponseDecodesPromptVersionAsNilWhenAbsentOrNull`
- `AnalysisViewModelTests.testRunCapturesLastPromptVersionFromSuggest`
- `AnalysisViewModelTests.testRunLeavesLastPromptVersionNilWhenSuggestOmitsField`
- `AnalysisViewModelTests.testResetClearsLastPromptVersion`
- `PhotoSuggestionOutcomesTests.testOutcomesRequestBodyCarriesPromptVersionWhenServerEchoedValue`
- `PhotoSuggestionOutcomesTests.testOutcomesRequestBodyCarriesNullPromptVersionWhenServerReturnedNone`
- `PhotoSuggestionOutcomesTests.testPriorSessionsPromptVersionDoesNotLeakWhenNewSessionReturnsNull`

Full suite: 8 new tests green; existing `SuggestionReviewViewModel*Tests` and `PhotoSuggestionOutcomesTests` all green; no new warnings.

The three pre-existing PR #19 failures (APIClient multipart drift x2, classification threshold constant-check x1) remain out of scope — not chased here.

## Deferred (confirmed out of scope by prompt)

- **Phase 2b-β** — `.ignored` decision (requires a dismiss gesture in the review UI)
- **Phase 2b-γ** — offline outcomes persistence

## Constraints honored

- No UI change (telemetry plumbing only)
- No `/confirm` path change; Swift2_013 error-surfacing invariants preserved
- No force unwraps
- No warning suppression
- No `-quiet` builds
