### PR TITLE
Swift2_016: defensive 64-char cap on decoded prompt_version (F8 follow-up)

### DIFF
--- a/Bin Brain/Bin Brain/Models/APIModels.swift
+++ b/Bin Brain/Bin Brain/Models/APIModels.swift
@@ -312,7 +312,19 @@ struct SuggestionItem: Decodable {
 /// stamp on cache hits (may differ from the live value after a prompt bump).
 /// Nil when the server did not echo the field (older server build or a future
 /// case where the value is genuinely absent).
+///
+/// Defensive decode (Swift2_016, aegis F8): `promptVersion` is clamped to
+/// `nil` at decode time when the server echoes an over-length value (> 64
+/// chars) or one containing ASCII control characters (< 0x20). Nil, not
+/// truncation — the whole point of `prompt_version` is lineage auditing,
+/// and a value we can't trust must become "unknown" rather than "incorrect."
 struct PhotoSuggestResponse: Decodable {
+    /// Max character count accepted for a server-echoed `prompt_version`.
+    /// Values exceeding this decode to nil. Current production values like
+    /// `"v2"` are two characters — 64 is a generous headroom, not a tight
+    /// limit.
+    private static let maxPromptVersionLength = 64
+
     let version: String
     let photoId: Int
     let model: String
@@ -327,6 +339,31 @@ struct PhotoSuggestResponse: Decodable {
         case promptVersion = "prompt_version"
         case visionElapsedMs = "vision_elapsed_ms"
         case suggestions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.version = try container.decode(String.self, forKey: .version)
+        self.photoId = try container.decode(Int.self, forKey: .photoId)
+        self.model = try container.decode(String.self, forKey: .model)
+        self.visionElapsedMs = try container.decode(Int.self, forKey: .visionElapsedMs)
+        self.suggestions = try container.decode([SuggestionItem].self, forKey: .suggestions)
+
+        let rawPromptVersion = try container.decodeIfPresent(String.self, forKey: .promptVersion)
+        self.promptVersion = Self.sanitizePromptVersion(rawPromptVersion)
+    }
+
+    /// Returns `raw` unchanged if it is nil, within the length cap, and
+    /// contains no ASCII control characters; returns `nil` otherwise.
+    /// Silent clamp — no logging, no truncation. Matches the existing
+    /// nil-forward telemetry contract from Swift2_015.
+    private static func sanitizePromptVersion(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        if raw.count > maxPromptVersionLength { return nil }
+        for scalar in raw.unicodeScalars where scalar.value < 0x20 {
+            return nil
+        }
+        return raw
     }
 }
 

--- a/Bin Brain/Bin BrainTests/APIModelsTests.swift
+++ b/Bin Brain/Bin BrainTests/APIModelsTests.swift
@@ -396,6 +396,103 @@ final class APIModelsTests: XCTestCase {
                      "absent prompt_version must decode as nil (backward compat with pre-PR#22 server builds)")
     }
 
+    // MARK: - Swift2_016 — Defensive length + control-char cap on prompt_version
+
+    /// Regression guard: the custom decoder must not break the existing
+    /// happy path. A normal server value (`"v2"`) decodes unchanged.
+    func testPhotoSuggestResponsePreservesNormalPromptVersion() throws {
+        let json = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": "v2",
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let response = try decode(PhotoSuggestResponse.self, from: json)
+        XCTAssertEqual(response.promptVersion, "v2")
+        // Other fields must still decode normally after the custom init took over.
+        XCTAssertEqual(response.version, "1")
+        XCTAssertEqual(response.photoId, 42)
+        XCTAssertEqual(response.model, "qwen3-vl:4b")
+        XCTAssertEqual(response.visionElapsedMs, 1200)
+        XCTAssertTrue(response.suggestions.isEmpty)
+    }
+
+    /// Boundary: exactly 64 characters is within the cap and decodes through.
+    func testPhotoSuggestResponseAllowsPromptVersionAtMaxLength() throws {
+        let sixtyFour = String(repeating: "a", count: 64)
+        XCTAssertEqual(sixtyFour.count, 64, "precondition — fixture is 64 chars")
+        let json = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": "\(sixtyFour)",
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let response = try decode(PhotoSuggestResponse.self, from: json)
+        XCTAssertEqual(response.promptVersion, sixtyFour,
+                       "64-char value is at the cap and must pass through unchanged")
+    }
+
+    /// F8: a malformed/compromised server echoing an over-length value
+    /// must become nil on iOS — never truncated (truncation would lie
+    /// about which prompt produced the decisions). Other fields must
+    /// continue to decode normally so the rest of the session is usable.
+    func testPhotoSuggestResponseClampsOverlengthPromptVersionToNil() throws {
+        let sixtyFive = String(repeating: "a", count: 65)
+        XCTAssertEqual(sixtyFive.count, 65, "precondition — fixture is 65 chars (one over cap)")
+        let json = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": "\(sixtyFive)",
+            "vision_elapsed_ms": 1200,
+            "suggestions": [
+                {"item_id": null, "name": "hex bolt", "category": null, "confidence": 0.9, "bins": []}
+            ]
+        }
+        """
+        let response = try decode(PhotoSuggestResponse.self, from: json)
+        XCTAssertNil(response.promptVersion,
+                     "over-length prompt_version must decode to nil — never truncated")
+        XCTAssertEqual(response.suggestions.count, 1,
+                       "other fields must decode normally even when prompt_version is rejected")
+        XCTAssertEqual(response.model, "qwen3-vl:4b")
+    }
+
+    /// F8: ASCII control characters (< 0x20) in a server-echoed value
+    /// indicate a malformed or tampered stream. Reject to nil.
+    ///
+    /// The JSON payload uses the `\u0007` escape sequence rather than a
+    /// raw BEL byte because strict JSON (RFC 8259) forbids unescaped
+    /// control characters in strings — JSONDecoder would throw at parse
+    /// time before the sanitizer ever saw the value. The escape yields
+    /// a Swift String whose unicodeScalars contain U+0007 once decoded.
+    func testPhotoSuggestResponseClampsControlCharPromptVersionToNil() throws {
+        let json = """
+        {
+            "version": "1",
+            "photo_id": 42,
+            "model": "qwen3-vl:4b",
+            "prompt_version": "v2\\u0007",
+            "vision_elapsed_ms": 1200,
+            "suggestions": []
+        }
+        """
+        let response = try decode(PhotoSuggestResponse.self, from: json)
+        XCTAssertNil(response.promptVersion,
+                     "prompt_version containing ASCII control chars must decode to nil")
+        XCTAssertEqual(response.model, "qwen3-vl:4b",
+                       "other fields must decode normally even when prompt_version is rejected")
+    }
+
     // MARK: - Test 9: Invalid JSON throws on missing required field
 
     func testDecodingBinSummaryThrowsOnMissingRequiredField() {


### PR DESCRIPTION
## Swift2_016 — Defensive 64-char cap on decoded `prompt_version` (F8 follow-up)

Closes **F8 (Low)** from the aegis SEC audit on PR #20 — see `.swarm/AssessmentReports/SEC_PR20_041826.md`. **Not a merge blocker**; this is defensive-decode hardening.

## Problem

`PhotoSuggestResponse.promptVersion` currently accepts an arbitrary `String?` from the server. A malformed or compromised server could echo oversized or control-character content that iOS would then re-emit on every `/outcomes` POST. aegis flagged this as an untyped server-string pass-through.

## Deliverable

Custom `init(from decoder:)` on `PhotoSuggestResponse` that clamps `promptVersion` at decode time:

- **Max length:** 64 characters (current production value is `"v2"` — generous headroom, not a tight limit).
- **Over-length behavior:** treat as `nil` (see rationale below).
- **Control-char behavior:** any Unicode scalar with code point `< 0x20` inside the decoded string → `nil`.
- All other fields pass through via normal Codable — no decoder added for them.

## Rationale: nil over truncation

`prompt_version` exists for lineage auditing. A value we can't trust must become **unknown** (nil), never **incorrect** (truncated). A truncated version string would be a lie about which prompt produced the decisions — worse than no signal at all.

Silent clamp matches the nil-forward telemetry contract introduced in Swift2_015: no logging, no error, no UI change.

## Self-contained

- `AnalysisViewModel`, `SuggestionReviewViewModel`, `APIClient`, `PhotoSuggestionOutcomesRequest` — **untouched**.
- The outcomes POST continues to forward whatever `lastPromptVersion` holds; capping at the decode boundary is sufficient.
- The server contract and `openapi.yaml` — **untouched** (purely iOS defensive).

## Tests

New in `APIModelsTests`:

- `testPhotoSuggestResponsePreservesNormalPromptVersion` — happy path (`"v2"` unchanged); regression guard that the custom decoder didn't break existing fields.
- `testPhotoSuggestResponseAllowsPromptVersionAtMaxLength` — exactly 64 chars passes.
- `testPhotoSuggestResponseClampsOverlengthPromptVersionToNil` — 65 chars → nil, other fields still decode.
- `testPhotoSuggestResponseClampsControlCharPromptVersionToNil` — `\u0007` (BEL) → nil.

All pass. Full `APIModelsTests` + `AnalysisViewModelTests` + `PhotoSuggestionOutcomesTests` suites clean; no regressions on the Swift2_015 test set.

## Review note

Architect will dispatch aegis for SEC review before merge — **do not merge**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API response validation to detect and safely handle malformed or suspicious metadata that exceeds safety limits or contains invalid control characters, improving robustness against untrusted or corrupted server data.

* **Tests**
  * Added comprehensive regression tests covering edge cases in API response field validation, including boundary conditions, length limits, and malformed data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->