### PR TITLE
feat(suggest): three-state outcome toggle (Swift2_020)

### DIFF
--- a/Bin Brain/Bin Brain/Models/OutcomeState.swift
+++ b/Bin Brain/Bin Brain/Models/OutcomeState.swift
@@ -1,0 +1,53 @@
+// OutcomeState.swift
+// Bin Brain
+//
+// Three-state outcome model used by the Swift2_020 suggestion-review tap
+// cycle: ignored (yellow, default) → accepted (green) → rejected (red) →
+// ignored. Tapping a row advances `next()`. The wire-format mapping in
+// `serverDecision` matches the values the binbrain server's
+// `photo_suggestion_outcomes.decision` column accepts.
+//
+// `Int` raw values let `EditableSuggestion` round-trip the field through
+// `Codable` without a custom container, and CaseIterable supports tests.
+
+import Foundation
+
+/// Per-row cataloging outcome surfaced by the three-state tap toggle.
+///
+/// Behind `outcomeModelEnabled = true` (Swift2_020 default), every row in
+/// the suggestion-review screen carries one of these states. Tapping the
+/// row chip cycles the value via `next()`.
+enum OutcomeState: Int, Codable, CaseIterable, Sendable {
+    /// Yellow chip, the spawn state under the three-state model. Items in
+    /// this state are NOT upserted on confirm; the `confirmButtonTitle`
+    /// surfaces the count so users see what they're about to skip.
+    case ignored = 0
+
+    /// Green chip. Item is selected for upsert; the outcome telemetry
+    /// classifies it `.accepted` (or `.edited` when the label diverged
+    /// from the prefilled value).
+    case accepted = 1
+
+    /// Red chip. Item is explicitly skipped from upsert AND emits a
+    /// `.rejected` decision in the outcome payload (negative training signal).
+    case rejected = 2
+
+    /// Returns the next state in the tap cycle.
+    func next() -> OutcomeState {
+        switch self {
+        case .ignored: return .accepted
+        case .accepted: return .rejected
+        case .rejected: return .ignored
+        }
+    }
+
+    /// Wire-format value for `photo_suggestion_outcomes.decision`. Stable
+    /// strings — the server's Pydantic enum reads these literally.
+    var serverDecision: String {
+        switch self {
+        case .ignored: return "ignored"
+        case .accepted: return "accepted"
+        case .rejected: return "rejected"
+        }
+    }
+}

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -66,6 +66,11 @@ struct EditableSuggestion: Identifiable {
     /// server wants for training, not the user's replacement. Nil for chips
     /// that did not come from a server suggestion (preliminary CoreML chips).
     let originalCategory: String?
+    /// Three-state outcome (Swift2_020). Defaults to `.accepted` so any code
+    /// path that constructs an `EditableSuggestion` without setting state
+    /// keeps the legacy default-on semantics. The view model overrides this
+    /// at `loadSuggestions` time when the feature flag is on.
+    var outcomeState: OutcomeState = .accepted
 }
 
 // MARK: - SuggestionReviewViewModel
@@ -204,15 +209,76 @@ final class SuggestionReviewViewModel {
     /// no public mutable seam.
     private let decoder: @Sendable (Data) -> UIImage?
 
+    // MARK: - Swift2_020 Three-State Outcome Toggle
+
+    /// `UserDefaults` key surfaced via `@AppStorage` in `SettingsView`.
+    /// Production default is `true` (three-state on); flipping to `false`
+    /// reverts the suggestion-review screen to legacy default-on UX without
+    /// a code release.
+    static let outcomeModelEnabledDefaultsKey = "outcomeModelEnabled"
+
+    /// Whether the three-state outcome toggle is active. Reads
+    /// `UserDefaults.standard` at init time so settings flips take effect on
+    /// the next sheet presentation; tests override directly.
+    var threeStateEnabled: Bool
+
+    /// Number of rows currently in the `.ignored` state. Drives
+    /// `confirmButtonTitle` so users can see what they're about to skip.
+    /// Always zero in legacy mode (rows arrive `.accepted`).
+    ///
+    /// - Complexity: O(n).
+    var ignoredCount: Int {
+        editableSuggestions.reduce(into: 0) { count, item in
+            if item.outcomeState == .ignored { count += 1 }
+        }
+    }
+
+    /// Title for the Confirm button. `"Confirm"` when nothing is ignored or
+    /// the flag is off; `"Confirm (N ignored)"` when N > 0 under three-state.
+    var confirmButtonTitle: String {
+        guard threeStateEnabled else { return "Confirm" }
+        let n = ignoredCount
+        return n == 0 ? "Confirm" : "Confirm (\(n) ignored)"
+    }
+
+    /// Advances `editableSuggestions[id].outcomeState` per the tap cycle and
+    /// keeps `included` in sync (only `.accepted` rows fire the upsert
+    /// pipeline). Unknown ids are no-ops.
+    func cycleOutcome(id: Int) {
+        guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }) else { return }
+        let newState = editableSuggestions[idx].outcomeState.next()
+        editableSuggestions[idx].outcomeState = newState
+        editableSuggestions[idx].included = (newState == .accepted)
+    }
+
     // MARK: - Init
 
     /// Creates a SuggestionReviewViewModel with an optional custom decoder.
     ///
-    /// - Parameter decoder: The function used to decode `photoData` JPEG bytes
-    ///   into a `UIImage`. Defaults to `UIImage(data:)`. Tests supply a
-    ///   capturing closure to observe the decode thread or intercept results.
-    init(decoder: @escaping @Sendable (Data) -> UIImage? = { UIImage(data: $0) }) {
+    /// - Parameters:
+    ///   - decoder: The function used to decode `photoData` JPEG bytes into a
+    ///     `UIImage`. Defaults to `UIImage(data:)`. Tests supply a capturing
+    ///     closure to observe the decode thread or intercept results.
+    ///   - threeStateEnabled: Override the `outcomeModelEnabled` user default.
+    ///     Production callers omit this so the value tracks Settings; tests
+    ///     pass an explicit Bool to pin the mode.
+    init(
+        decoder: @escaping @Sendable (Data) -> UIImage? = { UIImage(data: $0) },
+        threeStateEnabled: Bool? = nil
+    ) {
         self.decoder = decoder
+        if let threeStateEnabled {
+            self.threeStateEnabled = threeStateEnabled
+        } else {
+            // `UserDefaults.bool(forKey:)` returns `false` for an unset key,
+            // which would silently disable the flag on first launch. Read via
+            // `object(forKey:)` so an absent key falls back to the documented
+            // production default of `true`.
+            let stored = UserDefaults.standard.object(
+                forKey: Self.outcomeModelEnabledDefaultsKey
+            ) as? Bool
+            self.threeStateEnabled = stored ?? true
+        }
     }
 
     // MARK: - Setup
@@ -249,12 +315,16 @@ final class SuggestionReviewViewModel {
         // guarantees a reused VM cannot attach new decisions to old context.
         // (ultrareview bug_003 + CodeRabbit defense-in-depth follow-up.)
         resetOutcomesContext()
+        // Swift2_020 — under three-state, new rows arrive `.ignored`
+        // (yellow) and excluded; legacy mode keeps default-on `.accepted`.
+        let initialState: OutcomeState = threeStateEnabled ? .ignored : .accepted
+        let initialIncluded = (initialState == .accepted)
         editableSuggestions = suggestions.enumerated().map { idx, item in
             let name = item.match?.name ?? item.name
             let category = item.match?.category ?? item.category ?? ""
             return EditableSuggestion(
                 id: idx,
-                included: true,
+                included: initialIncluded,
                 editedName: name,
                 editedCategory: category,
                 editedQuantity: "",
@@ -263,7 +333,8 @@ final class SuggestionReviewViewModel {
                 match: item.match,
                 bbox: item.bbox,
                 teach: true,
-                originalCategory: item.category
+                originalCategory: item.category,
+                outcomeState: initialState
             )
         }
         failedIndices = []
@@ -393,10 +464,15 @@ final class SuggestionReviewViewModel {
         resetOutcomesContext()
         let limit = max(0, min(topK, classifications.count))
         originalPreliminaryTopK = Array(classifications.prefix(limit))
+        // Swift2_020 — preliminary chips obey the same three-state initial
+        // state as server suggestions, so the user sees a consistent yellow
+        // baseline regardless of which inference path produced the chip.
+        let initialState: OutcomeState = threeStateEnabled ? .ignored : .accepted
+        let initialIncluded = (initialState == .accepted)
         editableSuggestions = classifications.prefix(limit).enumerated().map { idx, cls in
             EditableSuggestion(
                 id: idx,
-                included: true,
+                included: initialIncluded,
                 editedName: cls.label,
                 editedCategory: "",
                 editedQuantity: "",
@@ -406,7 +482,8 @@ final class SuggestionReviewViewModel {
                 bbox: nil,
                 teach: true,
                 origin: .preliminary,
-                originalCategory: nil
+                originalCategory: nil,
+                outcomeState: initialState
             )
         }
         failedIndices = []
@@ -434,9 +511,18 @@ final class SuggestionReviewViewModel {
     }
 
     func markEditedIfPreliminary(id: Int) {
-        guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }),
-              editableSuggestions[idx].origin == .preliminary else { return }
-        editableSuggestions[idx].origin = .edited
+        guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }) else { return }
+        if editableSuggestions[idx].origin == .preliminary {
+            editableSuggestions[idx].origin = .edited
+        }
+        // Swift2_020 — editing implies endorsement: an .ignored row that the
+        // user starts modifying flips to .accepted so the upsert pipeline
+        // picks it up. .rejected rows stay rejected (require explicit
+        // re-tap to revive).
+        if threeStateEnabled, editableSuggestions[idx].outcomeState == .ignored {
+            editableSuggestions[idx].outcomeState = .accepted
+            editableSuggestions[idx].included = true
+        }
     }
 
     /// Reconciles the current preliminary chips with the server's suggestions.
@@ -460,7 +546,11 @@ final class SuggestionReviewViewModel {
         visionModel: String? = nil,
         promptVersion: String? = nil
     ) {
-        editableSuggestions = Self.merge(preliminary: editableSuggestions, server: server)
+        editableSuggestions = Self.merge(
+            preliminary: editableSuggestions,
+            server: server,
+            threeStateEnabled: threeStateEnabled
+        )
         applyOutcomesContext(
             photoId: photoId,
             visionModel: visionModel,
@@ -509,7 +599,8 @@ final class SuggestionReviewViewModel {
     /// the prompt's TDD plan (REFACTOR step).
     static func merge(
         preliminary: [EditableSuggestion],
-        server: [SuggestionItem]
+        server: [SuggestionItem],
+        threeStateEnabled: Bool = false
     ) -> [EditableSuggestion] {
         let editedChips = preliminary.filter { $0.origin == .edited }
         let editedNames = Set(editedChips.map { Self.normalize($0.editedName) })
@@ -517,6 +608,11 @@ final class SuggestionReviewViewModel {
         var result = editedChips
         var nextId = (result.map(\.id).max() ?? -1) + 1
 
+        // Server items added by merge follow the same three-state initial
+        // state as a fresh `loadSuggestions` call so the user sees a
+        // consistent baseline regardless of the load path.
+        let initialState: OutcomeState = threeStateEnabled ? .ignored : .accepted
+        let initialIncluded = (initialState == .accepted)
         for item in server {
             let key = Self.normalize(item.name)
             if editedNames.contains(key) { continue }
@@ -525,7 +621,7 @@ final class SuggestionReviewViewModel {
             result.append(
                 EditableSuggestion(
                     id: nextId,
-                    included: true,
+                    included: initialIncluded,
                     editedName: name,
                     editedCategory: category,
                     editedQuantity: "",
@@ -535,7 +631,8 @@ final class SuggestionReviewViewModel {
                     bbox: item.bbox,
                     teach: true,
                     origin: .server,
-                    originalCategory: item.category
+                    originalCategory: item.category,
+                    outcomeState: initialState
                 )
             )
             nextId += 1
@@ -580,10 +677,10 @@ final class SuggestionReviewViewModel {
     static func buildOutcomes(
         shownAt: Date,
         editable: [EditableSuggestion],
-        confirmedIds: Set<Int>
+        confirmedIds: Set<Int>,
+        threeStateEnabled: Bool = false
     ) -> [PhotoSuggestionOutcome] {
         editable.compactMap { item in
-            let confirmed = confirmedIds.contains(item.id)
             let finalLabel = item.editedName.trimmingCharacters(in: .whitespacesAndNewlines)
             let originalLabel = item.visionName
             // Edit-detection baseline is the value `editedName` was PREFILLED
@@ -593,19 +690,43 @@ final class SuggestionReviewViewModel {
             // as `.edited` (poisoning the training signal Swift2_014 exists
             // to collect — see ultrareview bug_001).
             let prefilledLabel = item.match?.name ?? item.visionName
-            let wasEdited = confirmed && !finalLabel.isEmpty && finalLabel != prefilledLabel
+            let labelChanged = !finalLabel.isEmpty && finalLabel != prefilledLabel
 
             let decision: PhotoSuggestionOutcome.Decision
             let editedTo: String?
-            if wasEdited {
-                decision = .edited
-                editedTo = finalLabel
-            } else if confirmed {
-                decision = .accepted
-                editedTo = nil
+            if threeStateEnabled {
+                // Swift2_020 — `outcomeState` is authoritative. `.accepted`
+                // with a divergent label still surfaces as `.edited` so the
+                // training signal mirrors what the user actually saved.
+                switch item.outcomeState {
+                case .accepted:
+                    if labelChanged {
+                        decision = .edited
+                        editedTo = finalLabel
+                    } else {
+                        decision = .accepted
+                        editedTo = nil
+                    }
+                case .rejected:
+                    decision = .rejected
+                    editedTo = nil
+                case .ignored:
+                    decision = .ignored
+                    editedTo = nil
+                }
             } else {
-                decision = .rejected
-                editedTo = nil
+                let confirmed = confirmedIds.contains(item.id)
+                let wasEdited = confirmed && labelChanged
+                if wasEdited {
+                    decision = .edited
+                    editedTo = finalLabel
+                } else if confirmed {
+                    decision = .accepted
+                    editedTo = nil
+                } else {
+                    decision = .rejected
+                    editedTo = nil
+                }
             }
 
             if decision == .edited, (editedTo ?? "").isEmpty {
@@ -641,7 +762,8 @@ final class SuggestionReviewViewModel {
         let decisions = Self.buildOutcomes(
             shownAt: shownAt,
             editable: editableSuggestions,
-            confirmedIds: confirmedIds
+            confirmedIds: confirmedIds,
+            threeStateEnabled: threeStateEnabled
         )
         let request = PhotoSuggestionOutcomesRequest(
             visionModel: visionModel,

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -510,15 +510,20 @@ final class SuggestionReviewViewModel {
         editableSuggestions[index].origin = .edited
     }
 
-    func markEditedIfPreliminary(id: Int) {
+    /// Single onChange entry point for any editable field on a row.
+    ///
+    /// Two responsibilities (was named `markEditedIfPreliminary(id:)` before
+    /// Swift2_020; renamed because it now carries a second concern):
+    /// 1. Promote a `.preliminary` chip to `.edited` so the merge rules in
+    ///    `merge(preliminary:server:threeStateEnabled:)` keep it.
+    /// 2. Under three-state, flip an `.ignored` row to `.accepted` (editing
+    ///    implies endorsement). `.rejected` rows do NOT auto-resurrect —
+    ///    that requires an explicit chip tap.
+    func noteUserEdit(id: Int) {
         guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }) else { return }
         if editableSuggestions[idx].origin == .preliminary {
             editableSuggestions[idx].origin = .edited
         }
-        // Swift2_020 — editing implies endorsement: an .ignored row that the
-        // user starts modifying flips to .accepted so the upsert pipeline
-        // picks it up. .rejected rows stay rejected (require explicit
-        // re-tap to revive).
         if threeStateEnabled, editableSuggestions[idx].outcomeState == .ignored {
             editableSuggestions[idx].outcomeState = .accepted
             editableSuggestions[idx].included = true

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -300,20 +300,20 @@ struct SuggestionReviewView: View {
             TextField("Name", text: suggestion.editedName)
                 .textFieldStyle(.roundedBorder)
                 .onChange(of: s.editedName) { _, _ in
-                    viewModel.markEditedIfPreliminary(id: s.id)
+                    viewModel.noteUserEdit(id: s.id)
                 }
 
             TextField("Category", text: suggestion.editedCategory)
                 .textFieldStyle(.roundedBorder)
                 .onChange(of: s.editedCategory) { _, _ in
-                    viewModel.markEditedIfPreliminary(id: s.id)
+                    viewModel.noteUserEdit(id: s.id)
                 }
 
             TextField("Quantity", text: suggestion.editedQuantity)
                 .textFieldStyle(.roundedBorder)
                 .keyboardType(.decimalPad)
                 .onChange(of: s.editedQuantity) { _, _ in
-                    viewModel.markEditedIfPreliminary(id: s.id)
+                    viewModel.noteUserEdit(id: s.id)
                 }
 
             Toggle(isOn: suggestion.teach) {
@@ -342,9 +342,11 @@ struct SuggestionReviewView: View {
     ///
     /// Don't-rely-on-color: renders a distinct SF Symbol per state on top of
     /// the color fill so users without color perception still read the state
-    /// from the icon shape. A short fade cross-dissolves the chip when the
-    /// state changes; no spring, no bounce (HIG: respect reduced-motion; the
-    /// fade is brief enough that it renders as a state swap, not animation).
+    /// from the icon shape. A brief `.easeInOut(0.15)` envelope wraps
+    /// `cycleOutcome` and `.contentTransition(.symbolEffect(.replace))`
+    /// swaps the glyph with the system's SF-Symbol replace effect — no
+    /// spring, no bounce, quick enough to read as a state swap rather than
+    /// an animation.
     private func outcomeChip(for suggestion: EditableSuggestion) -> some View {
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -191,7 +191,13 @@ struct SuggestionReviewView: View {
                     }
                     .disabled(viewModel.isConfirming)
                 } else if viewModel.canConfirm {
-                    Button("Confirm") {
+                    // Swift2_020 — `confirmButtonTitle` shows the ignored count
+                    // under three-state so users see what they are skipping.
+                    // Still tappable with ignored rows present; the label is
+                    // the guardrail (not a hard block) per the plan's rationale
+                    // against forcing per-row engagement when the user simply
+                    // doesn't care about some items.
+                    Button(viewModel.confirmButtonTitle) {
                         Task {
                             await viewModel.confirm(binId: viewModel.binId, apiClient: apiClient)
                         }
@@ -230,10 +236,22 @@ struct SuggestionReviewView: View {
                     .accessibilityLabel("Preliminary suggestion, confirming with AI")
             }
             HStack {
-                Toggle(isOn: suggestion.included) {
+                // Swift2_020 — three-state chip replaces the legacy Toggle when
+                // the feature flag is on. The Toggle path stays available so
+                // a Settings flip (no code release) reverts to the default-on
+                // UX without losing any other row behaviour.
+                if viewModel.threeStateEnabled {
+                    outcomeChip(for: s)
                     Text(s.editedName)
                         .font(.headline)
                         .foregroundStyle(isPreliminary ? .secondary : .primary)
+                    Spacer(minLength: 0)
+                } else {
+                    Toggle(isOn: suggestion.included) {
+                        Text(s.editedName)
+                            .font(.headline)
+                            .foregroundStyle(isPreliminary ? .secondary : .primary)
+                    }
                 }
 
                 if !isPreliminary {
@@ -316,6 +334,75 @@ struct SuggestionReviewView: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityHint(isPreliminary ? "Preliminary — will be confirmed by the server" : "")
+    }
+
+    // MARK: - Swift2_020 Three-State Chip
+
+    /// Tappable chip that cycles the row's `OutcomeState` on each tap.
+    ///
+    /// Don't-rely-on-color: renders a distinct SF Symbol per state on top of
+    /// the color fill so users without color perception still read the state
+    /// from the icon shape. A short fade cross-dissolves the chip when the
+    /// state changes; no spring, no bounce (HIG: respect reduced-motion; the
+    /// fade is brief enough that it renders as a state swap, not animation).
+    private func outcomeChip(for suggestion: EditableSuggestion) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                viewModel.cycleOutcome(id: suggestion.id)
+            }
+        } label: {
+            Image(systemName: Self.chipIcon(for: suggestion.outcomeState))
+                .font(.title2)
+                .foregroundStyle(.white)
+                .padding(6)
+                .background(
+                    Circle()
+                        .fill(Self.chipColor(for: suggestion.outcomeState))
+                )
+                .overlay(
+                    Circle()
+                        .strokeBorder(.primary.opacity(0.15), lineWidth: 0.5)
+                )
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.chipAccessibilityLabel(
+            name: suggestion.editedName,
+            state: suggestion.outcomeState
+        ))
+        .accessibilityHint(Self.chipAccessibilityHint(current: suggestion.outcomeState))
+    }
+
+    private static func chipIcon(for state: OutcomeState) -> String {
+        switch state {
+        case .ignored: return "circle"
+        case .accepted: return "checkmark"
+        case .rejected: return "xmark"
+        }
+    }
+
+    private static func chipColor(for state: OutcomeState) -> Color {
+        switch state {
+        case .ignored: return .yellow
+        case .accepted: return .green
+        case .rejected: return .red
+        }
+    }
+
+    private static func chipAccessibilityLabel(name: String, state: OutcomeState) -> String {
+        switch state {
+        case .ignored: return "\(name), ignored"
+        case .accepted: return "\(name), accepted"
+        case .rejected: return "\(name), rejected"
+        }
+    }
+
+    private static func chipAccessibilityHint(current: OutcomeState) -> String {
+        switch current.next() {
+        case .ignored: return "Double-tap to ignore"
+        case .accepted: return "Double-tap to accept"
+        case .rejected: return "Double-tap to reject"
+        }
     }
 
     // MARK: - Bbox Geometry

--- a/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
+++ b/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
@@ -28,6 +28,13 @@ struct SettingsView: View {
     /// (Finding #9). Kept in the view, not the view model, because it's pure UI.
     @State private var showModelSelectToast: Bool = false
 
+    /// Swift2_020 — three-state outcome toggle feature flag. Default `true`
+    /// (yellow/green/red tap-cycle UX in suggestion review). Flipping to
+    /// `false` reverts the sheet to the legacy default-on toggle without a
+    /// code release — the VM reads the same key at init time.
+    @AppStorage(SuggestionReviewViewModel.outcomeModelEnabledDefaultsKey)
+    private var outcomeModelEnabled: Bool = true
+
     // MARK: - Body
 
     var body: some View {
@@ -46,6 +53,7 @@ struct SettingsView: View {
             visionModelSection
             imageSizeSection
             searchSection
+            catalogingSection
             uploadQueueSection
         }
         .navigationTitle("Settings")
@@ -348,6 +356,18 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var catalogingSection: some View {
+        Section("Cataloging") {
+            Toggle("Three-state outcome toggle", isOn: $outcomeModelEnabled)
+            Text(outcomeModelEnabled
+                 ? "Tap each suggestion to cycle: ignored (yellow) → accepted (green) → rejected (red). Only accepted items are saved."
+                 : "Legacy behaviour: every suggestion is accepted by default — flip its switch to exclude.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Bin Brain/Bin BrainTests/OutcomeStateTests.swift
+++ b/Bin Brain/Bin BrainTests/OutcomeStateTests.swift
@@ -1,0 +1,52 @@
+// OutcomeStateTests.swift
+// Bin BrainTests
+//
+// Coverage for the three-state outcome enum used by Swift2_020.
+// The enum is the foundation of the tap-cycle UI: ignored (yellow, default)
+// → accepted (green) → rejected (red) → ignored. Server payloads use the
+// `serverDecision` mapping so the wire format stays stable.
+
+import XCTest
+@testable import Bin_Brain
+
+final class OutcomeStateTests: XCTestCase {
+
+    // MARK: - Tap cycle
+
+    func testNextFromIgnoredYieldsAccepted() {
+        XCTAssertEqual(OutcomeState.ignored.next(), .accepted,
+                       "First tap on an ignored row must advance to accepted")
+    }
+
+    func testNextFromAcceptedYieldsRejected() {
+        XCTAssertEqual(OutcomeState.accepted.next(), .rejected,
+                       "Second tap must advance from accepted to rejected")
+    }
+
+    func testNextFromRejectedYieldsIgnored() {
+        XCTAssertEqual(OutcomeState.rejected.next(), .ignored,
+                       "Third tap must wrap rejected back to ignored")
+    }
+
+    func testThreeTapsReturnToIgnored() {
+        let result = OutcomeState.ignored.next().next().next()
+        XCTAssertEqual(result, .ignored,
+                       "Three taps starting from ignored must complete the cycle")
+    }
+
+    // MARK: - Server-decision mapping
+
+    func testServerDecisionMappingMatchesSpec() {
+        XCTAssertEqual(OutcomeState.ignored.serverDecision, "ignored")
+        XCTAssertEqual(OutcomeState.accepted.serverDecision, "accepted")
+        XCTAssertEqual(OutcomeState.rejected.serverDecision, "rejected")
+    }
+
+    func testAllCasesIsExactlyThreeStates() {
+        XCTAssertEqual(OutcomeState.allCases.count, 3,
+                       "Three-state model must have exactly three cases")
+        XCTAssertTrue(OutcomeState.allCases.contains(.ignored))
+        XCTAssertTrue(OutcomeState.allCases.contains(.accepted))
+        XCTAssertTrue(OutcomeState.allCases.contains(.rejected))
+    }
+}

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -73,6 +73,10 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         sut = SuggestionReviewViewModel()
+        // Outcome telemetry tests pre-date Swift2_020 and assert legacy
+        // semantics (no .ignored decisions emitted; rows arrive included).
+        // Three-state telemetry is covered in SuggestionReviewThreeStateTests.swift.
+        sut.threeStateEnabled = false
     }
 
     override func tearDown() async throws {

--- a/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
@@ -132,7 +132,7 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
         XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .ignored, "precondition: ignored")
 
         sut.editableSuggestions[0].editedName = "Widget XL"
-        sut.markEditedIfPreliminary(id: id)
+        sut.noteUserEdit(id: id)
 
         XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .accepted,
                        "Editing an ignored row implies endorsement → state must auto-flip to .accepted")
@@ -146,7 +146,7 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
         sut.cycleOutcome(id: id) // → .accepted
 
         sut.editableSuggestions[0].editedName = "Widget XL"
-        sut.markEditedIfPreliminary(id: id)
+        sut.noteUserEdit(id: id)
 
         XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .accepted,
                        "Editing an already-accepted row must stay accepted")
@@ -159,7 +159,7 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
         sut.cycleOutcome(id: id) // .rejected
 
         sut.editableSuggestions[0].editedName = "Widget XL"
-        sut.markEditedIfPreliminary(id: id)
+        sut.noteUserEdit(id: id)
 
         XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .rejected,
                        "Editing a rejected row must NOT re-include it; user must explicitly tap to revive")
@@ -235,7 +235,7 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
         }
 
         await sut.confirm(binId: "BIN-0001", apiClient: client)
-        // Outcomes are fire-and-forget; give the detached Task a chance to complete.
+        // Outcomes are fire-and-forget; give the spawned Task a chance to complete.
         await Task.yield()
         try await Task.sleep(nanoseconds: 50_000_000)
 
@@ -426,8 +426,9 @@ private extension URLRequest {
 
 /// Locked Data box so the URLProtocol callback (executed on a background
 /// queue) can hand a captured request body back to the test thread without
-/// triggering Swift 6 sendable warnings.
-final class OutcomesBodyCapture: @unchecked Sendable {
+/// triggering Swift 6 sendable warnings. File-private to avoid polluting
+/// the test target's symbol namespace (Copilot review feedback).
+private final class OutcomesBodyCapture: @unchecked Sendable {
     private let lock = NSLock()
     private var stored: Data?
     func set(_ data: Data?) {

--- a/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
@@ -1,0 +1,420 @@
+// SuggestionReviewThreeStateTests.swift
+// Bin BrainTests
+//
+// Coverage for the Swift2_020 three-state outcome toggle behavior on
+// SuggestionReviewViewModel. Existing legacy-mode tests live in
+// SuggestionReviewViewModelTests.swift; this file only exercises the
+// flag-on (`outcomeModelEnabled = true`) code path so the two modes are
+// validated independently.
+
+import XCTest
+@testable import Bin_Brain
+
+@MainActor
+final class SuggestionReviewThreeStateTests: XCTestCase {
+
+    var sut: SuggestionReviewViewModel!
+
+    // MARK: - Lifecycle
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SuggestionReviewViewModel()
+        sut.threeStateEnabled = true
+    }
+
+    override func tearDown() async throws {
+        SuggestionReviewMockURLProtocol.requestHandler = nil
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockAPIClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        SuggestionReviewMockURLProtocol.requestHandler = handler
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SuggestionReviewMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func mockResponse(statusCode: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private var upsertSuccessJSON: Data {
+        Data("""
+        {"version":"1","item_id":101,"fingerprint":"widget|hardware","name":"Widget","category":"Hardware"}
+        """.utf8)
+    }
+
+    private var associateSuccessJSON: Data {
+        Data("""
+        {"ok":true,"bin_id":"BIN-0001","item_id":101}
+        """.utf8)
+    }
+
+    private var confirmClassSuccessJSON: Data {
+        Data("""
+        {"version":"1","class_name":"Widget","added":true,"active_class_count":47,"reload_triggered":true}
+        """.utf8)
+    }
+
+    private func makeSuggestions() throws -> [SuggestionItem] {
+        let json = Data("""
+        [
+            {"item_id": null, "name": "Widget", "category": "Hardware", "confidence": 0.92, "bins": ["BIN-0001"]},
+            {"item_id": 5, "name": "Bolt", "category": "Fasteners", "confidence": 0.78, "bins": ["BIN-0001"]}
+        ]
+        """.utf8)
+        return try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+    }
+
+    // MARK: - Default state
+
+    func testNewRowsDefaultToIgnoredUnderThreeState() throws {
+        sut.loadSuggestions(try makeSuggestions())
+
+        XCTAssertEqual(sut.editableSuggestions.count, 2)
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.outcomeState == .ignored },
+                      "Three-state default for new rows must be .ignored")
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { !$0.included },
+                      "Ignored rows must NOT be included in confirm payload")
+    }
+
+    // MARK: - Tap cycle
+
+    func testCycleOutcomeAdvancesPerSpec() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let id = sut.editableSuggestions[0].id
+
+        sut.cycleOutcome(id: id)
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .accepted)
+        XCTAssertTrue(sut.editableSuggestions[0].included,
+                      "Accepted rows must mirror to included == true so confirm picks them up")
+
+        sut.cycleOutcome(id: id)
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .rejected)
+        XCTAssertFalse(sut.editableSuggestions[0].included,
+                       "Rejected rows must drop out of confirm payload")
+
+        sut.cycleOutcome(id: id)
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .ignored,
+                       "Three taps must complete the cycle back to ignored")
+        XCTAssertFalse(sut.editableSuggestions[0].included)
+    }
+
+    func testCycleOutcomeUnknownIdIsNoOp() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let snapshot = sut.editableSuggestions.map(\.outcomeState)
+
+        sut.cycleOutcome(id: 9999)
+
+        XCTAssertEqual(sut.editableSuggestions.map(\.outcomeState), snapshot,
+                       "Unknown id must not mutate state — Karpathy: surgical changes")
+    }
+
+    // MARK: - Edit-flips-to-accepted
+
+    func testEditingIgnoredRowAutoFlipsToAccepted() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let id = sut.editableSuggestions[0].id
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .ignored, "precondition: ignored")
+
+        sut.editableSuggestions[0].editedName = "Widget XL"
+        sut.markEditedIfPreliminary(id: id)
+
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .accepted,
+                       "Editing an ignored row implies endorsement → state must auto-flip to .accepted")
+        XCTAssertTrue(sut.editableSuggestions[0].included,
+                      "Auto-flipped row must be included so the upsert fires")
+    }
+
+    func testEditingAcceptedRowDoesNotChangeState() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let id = sut.editableSuggestions[0].id
+        sut.cycleOutcome(id: id) // → .accepted
+
+        sut.editableSuggestions[0].editedName = "Widget XL"
+        sut.markEditedIfPreliminary(id: id)
+
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .accepted,
+                       "Editing an already-accepted row must stay accepted")
+    }
+
+    func testEditingRejectedRowDoesNotResurrectIt() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let id = sut.editableSuggestions[0].id
+        sut.cycleOutcome(id: id) // .accepted
+        sut.cycleOutcome(id: id) // .rejected
+
+        sut.editableSuggestions[0].editedName = "Widget XL"
+        sut.markEditedIfPreliminary(id: id)
+
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, .rejected,
+                       "Editing a rejected row must NOT re-include it; user must explicitly tap to revive")
+    }
+
+    // MARK: - confirmButtonTitle
+
+    func testConfirmButtonTitleNoIgnored() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        for s in sut.editableSuggestions { sut.cycleOutcome(id: s.id) } // all → .accepted
+
+        XCTAssertEqual(sut.ignoredCount, 0)
+        XCTAssertEqual(sut.confirmButtonTitle, "Confirm",
+                       "With zero ignored, the title must read just 'Confirm'")
+    }
+
+    func testConfirmButtonTitleReflectsIgnoredCount() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        // Both default ignored.
+        XCTAssertEqual(sut.ignoredCount, 2)
+        XCTAssertEqual(sut.confirmButtonTitle, "Confirm (2 ignored)",
+                       "Two ignored rows → 'Confirm (2 ignored)'")
+
+        sut.cycleOutcome(id: sut.editableSuggestions[0].id) // → .accepted
+        XCTAssertEqual(sut.ignoredCount, 1)
+        XCTAssertEqual(sut.confirmButtonTitle, "Confirm (1 ignored)")
+    }
+
+    func testConfirmButtonTitleLegacyAlwaysReadsConfirm() throws {
+        sut.threeStateEnabled = false
+        sut.loadSuggestions(try makeSuggestions())
+
+        XCTAssertEqual(sut.confirmButtonTitle, "Confirm",
+                       "Legacy mode must never expose ignored-count in the button label")
+    }
+
+    // MARK: - canConfirm under three-state
+
+    func testCanConfirmRequiresAtLeastOneAccepted() throws {
+        sut.loadSuggestions(try makeSuggestions())
+        XCTAssertFalse(sut.canConfirm,
+                       "All-ignored should not allow confirm — there's nothing to upsert")
+
+        sut.cycleOutcome(id: sut.editableSuggestions[0].id) // → .accepted
+        XCTAssertTrue(sut.canConfirm,
+                      "One accepted row must enable confirm even if others are ignored/rejected")
+    }
+
+    // MARK: - Confirm payload — outcome decisions
+
+    func testConfirmEmitsAcceptedAndIgnoredDecisionsInPayload() async throws {
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 42,
+                            visionModel: "vision-test",
+                            promptVersion: "v1")
+        // Accept the first row, leave the second .ignored.
+        sut.cycleOutcome(id: sut.editableSuggestions[0].id)
+
+        let outcomesBody = OutcomesBodyCapture()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesBody.set(request.bodyData)
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        // Outcomes are fire-and-forget; give the detached Task a chance to complete.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let body = try XCTUnwrap(outcomesBody.value, "outcomes POST must fire on confirm-success")
+        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let decisions = try XCTUnwrap(payload?["decisions"] as? [[String: Any]],
+                                      "payload must include decisions array")
+        let decisionValues = decisions.compactMap { $0["decision"] as? String }
+        XCTAssertEqual(Set(decisionValues), Set(["accepted", "ignored"]),
+                       "Per-row decision must reflect each row's outcomeState; got \(decisionValues)")
+    }
+
+    func testConfirmEmitsRejectedDecision() async throws {
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 7,
+                            visionModel: "vision-test",
+                            promptVersion: nil)
+        sut.cycleOutcome(id: sut.editableSuggestions[0].id) // → .accepted
+        sut.cycleOutcome(id: sut.editableSuggestions[1].id) // → .accepted
+        sut.cycleOutcome(id: sut.editableSuggestions[1].id) // → .rejected
+
+        let outcomesBody = OutcomesBodyCapture()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesBody.set(request.bodyData)
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let body = try XCTUnwrap(outcomesBody.value)
+        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let decisions = try XCTUnwrap(payload?["decisions"] as? [[String: Any]])
+        let decisionValues = decisions.compactMap { $0["decision"] as? String }
+        XCTAssertEqual(Set(decisionValues), Set(["accepted", "rejected"]),
+                       "Mixed accepted+rejected must surface both decisions; got \(decisionValues)")
+    }
+
+    func testConfirmRejectedRowsDoNotUpsert() async throws {
+        sut.loadSuggestions(try makeSuggestions())
+        // Cycle both rows to .rejected.
+        for s in sut.editableSuggestions {
+            sut.cycleOutcome(id: s.id) // .accepted
+            sut.cycleOutcome(id: s.id) // .rejected
+        }
+
+        var upsertCount = 0
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path == "/items" { upsertCount += 1 }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+
+        XCTAssertEqual(upsertCount, 0,
+                       "Rejected rows must not hit /items — only .accepted upserts")
+    }
+
+    func testConfirmEditedAcceptedRowEmitsEditedDecision() async throws {
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 11,
+                            visionModel: "vision-test",
+                            promptVersion: "v1")
+        let id = sut.editableSuggestions[0].id
+        sut.cycleOutcome(id: id) // .accepted
+        sut.editableSuggestions[0].editedName = "Renamed Widget"
+        // Second row stays ignored.
+
+        let outcomesBody = OutcomesBodyCapture()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesBody.set(request.bodyData)
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let body = try XCTUnwrap(outcomesBody.value)
+        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let decisions = try XCTUnwrap(payload?["decisions"] as? [[String: Any]])
+        let edited = decisions.first { ($0["label"] as? String) == "Widget" }
+        XCTAssertEqual(edited?["decision"] as? String, "edited",
+                       "An accepted row whose name diverged from the prefilled label must emit .edited")
+        XCTAssertEqual(edited?["edited_to_label"] as? String, "Renamed Widget")
+    }
+
+    // MARK: - Feature-flag-off mirrors legacy
+
+    func testFlagOffDefaultsRowsToAccepted() throws {
+        sut.threeStateEnabled = false
+        sut.loadSuggestions(try makeSuggestions())
+
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.outcomeState == .accepted },
+                      "Legacy mode preserves default-on UX: rows arrive accepted")
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.included },
+                      "Legacy mode keeps included == true so confirm uploads everything")
+        XCTAssertEqual(sut.ignoredCount, 0)
+    }
+
+    func testFlagOffNeverEmitsIgnoredDecision() async throws {
+        sut.threeStateEnabled = false
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 99,
+                            visionModel: "vision-test",
+                            promptVersion: nil)
+        // Exclude the second row the legacy way.
+        sut.editableSuggestions[1].included = false
+
+        let outcomesBody = OutcomesBodyCapture()
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesBody.set(request.bodyData)
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let body = try XCTUnwrap(outcomesBody.value)
+        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let decisions = try XCTUnwrap(payload?["decisions"] as? [[String: Any]])
+        let decisionValues = decisions.compactMap { $0["decision"] as? String }
+        XCTAssertFalse(decisionValues.contains("ignored"),
+                       "Legacy mode must never emit .ignored — old payload semantics preserved")
+        XCTAssertEqual(Set(decisionValues), Set(["accepted", "rejected"]),
+                       "Legacy mode classifies excluded rows as .rejected")
+    }
+}
+
+// MARK: - Helpers
+
+/// Locked Data box so the URLProtocol callback (executed on a background
+/// queue) can hand a captured request body back to the test thread without
+/// triggering Swift 6 sendable warnings.
+final class OutcomesBodyCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Data?
+    func set(_ data: Data?) {
+        lock.lock(); defer { lock.unlock() }
+        stored = data
+    }
+    var value: Data? {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
+}

--- a/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
@@ -403,6 +403,27 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
 
 // MARK: - Helpers
 
+/// File-local mirror of the `bodyData` helper in SuggestionReviewViewModelTests
+/// so this file does not need a cross-file `internal` extension. Reads the
+/// request body from `httpBody` or drains `httpBodyStream` as a fallback.
+private extension URLRequest {
+    var bodyData: Data? {
+        if let data = httpBody { return data }
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 65_536
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(&buffer, maxLength: bufferSize)
+            guard bytesRead > 0 else { break }
+            data.append(contentsOf: buffer.prefix(bytesRead))
+        }
+        return data
+    }
+}
+
 /// Locked Data box so the URLProtocol callback (executed on a background
 /// queue) can hand a captured request body back to the test thread without
 /// triggering Swift 6 sendable warnings.

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
@@ -17,6 +17,10 @@ final class SuggestionReviewViewModelPreliminaryTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         sut = SuggestionReviewViewModel()
+        // Preliminary tests pre-date Swift2_020 and assert legacy default-on
+        // semantics (preliminaries arrive included == true). The three-state
+        // behavior is covered in SuggestionReviewThreeStateTests.swift.
+        sut.threeStateEnabled = false
     }
 
     override func tearDown() async throws {

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
@@ -75,6 +75,11 @@ final class SuggestionReviewViewModelTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         sut = SuggestionReviewViewModel()
+        // Legacy default-on UX is the rollback target for Swift2_020. These
+        // pre-existing tests assert the legacy semantics (rows arrive
+        // included == true). Three-state behavior is covered separately in
+        // SuggestionReviewThreeStateTests.swift.
+        sut.threeStateEnabled = false
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
## Swift2_020 — Three-State Outcome Toggle (2b-β)

Replaces the default-on accept-everything UX in suggestion review with a
tap-cycle three-state toggle: **yellow (ignored, default)** → **green (accepted)**
→ **red (rejected)** → **yellow**. Behind a feature flag for zero-code rollback.

Plan: `../binbrain/thoughts/shared/plans/2026-04-19-swift2b-beta-three-state-toggle.md`
Server impact: none (existing `decision='ignored'` is already accepted by `/photos/{id}/outcomes`).

### What changed

- **`OutcomeState` enum** (Int, Codable, CaseIterable) with `next()` cycle and
  `serverDecision` wire mapping (`ignored` / `accepted` / `rejected`).
- **`SuggestionReviewViewModel`** gains:
  - `threeStateEnabled` (reads `UserDefaults.outcomeModelEnabled`, default `true`)
  - `cycleOutcome(id:)` — advances state and mirrors `included = (newState == .accepted)`
  - `ignoredCount`, `confirmButtonTitle` ("Confirm" or "Confirm (N ignored)")
  - `loadSuggestions` / `loadPreliminaryClassifications` / `merge(...)` set the
    initial state from the flag (ignored under three-state, accepted under legacy).
  - `markEditedIfPreliminary(id:)` auto-flips an `.ignored` row to `.accepted`
    on edit (rejected stays rejected — explicit revival required).
  - `buildOutcomes` honors `outcomeState` directly under three-state; legacy
    path preserved exactly when the flag is off.
- **`EditableSuggestion`** gets `outcomeState: OutcomeState = .accepted` (default
  preserves legacy constructors).
- **`SuggestionReviewView`** renders a tappable color+icon chip per row when the
  flag is on (yellow circle / green check / red xmark + 0.15s easeInOut fade);
  the legacy `Toggle` path stays available for rollback. Confirm button uses
  `viewModel.confirmButtonTitle` and remains tappable when ignored rows exist
  (label is the soft guardrail per spec, not a hard block).
- **`SettingsView`** gains a "Cataloging" section with an `@AppStorage`-backed
  toggle and a state-aware explainer.

### Tests (TDD)

- New `OutcomeStateTests` (6 cases): tap cycle, server-decision mapping, allCases.
- New `SuggestionReviewThreeStateTests` (16 cases): default ignored, cycle,
  edit-flips-to-accepted, edit-on-rejected-no-resurrect, `confirmButtonTitle`
  with/without ignored, `canConfirm` semantics, payload `decisions` for
  accepted/ignored/rejected/edited, rejected-no-upsert, flag-off legacy parity
  (default `.accepted`, never emits `.ignored`).
- Existing 28+ `SuggestionReviewViewModelTests`, `SuggestionReviewViewModelPreliminaryTests`,
  and `PhotoSuggestionOutcomesTests` opt into legacy via `setUp`
  (`sut.threeStateEnabled = false`) and continue to pass — they cover the
  rollback path. Three-state coverage lives in the new file.
- All 468 tests pass on iPhone 17 simulator.
- All test URL traffic is intercepted by `URLProtocol` mocks (`SuggestionReviewMockURLProtocol`,
  `OutcomesMockURLProtocol`); no real network calls — no risk of polluting prod DB.

### Out of scope (per prompt)

- Confidence-driven default per item (Phase 5).
- "Accept all" / "Reject all" row buttons.
- Server changes — `ApiDev_010` is the separate doc-only follow-up.

### How to verify

1. Toggle Settings → Cataloging → "Three-state outcome toggle" off and on.
2. Capture a photo; the suggestion-review rows arrive with yellow circles.
3. Tap a row → green check; tap again → red xmark; tap again → yellow.
4. Edit an ignored row's name → it auto-flips to green (accepted).
5. Confirm with mixed states; check that `/photos/{id}/outcomes` payload
   contains the per-row decisions matching what you saw.

🤖 Generated for Swift2_020.
