### PR TITLE
feat(outcomes): offline queue with retry + telemetry (Swift2_018)

### DIFF
--- a/Bin Brain/Bin Brain/Bin_BrainApp.swift
+++ b/Bin Brain/Bin Brain/Bin_BrainApp.swift
@@ -19,6 +19,7 @@ struct Bin_BrainApp: App {
 
     @State private var apiClient = APIClient()
     @State private var uploadQueueManager = UploadQueueManager()
+    @State private var outcomeQueueManager = OutcomeQueueManager()
     @State private var serverMonitor = ServerMonitor()
 
     // MARK: - Initializer
@@ -46,6 +47,7 @@ struct Bin_BrainApp: App {
         let schema = Schema([
             PendingUpload.self,
             PendingAnalysis.self,
+            PendingOutcome.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
         do {
@@ -61,8 +63,18 @@ struct Bin_BrainApp: App {
         WindowGroup {
             RootView()
                 .task { await requestNotificationPermission() }
+                .task {
+                    // Swift2_018 — start NWPathMonitor + foreground observer
+                    // for the outcomes queue so retries fire automatically
+                    // on connectivity recovery. Idempotent.
+                    outcomeQueueManager.startMonitoring(
+                        context: sharedModelContainer.mainContext,
+                        apiClient: apiClient
+                    )
+                }
                 .environment(\.apiClient, apiClient)
                 .environment(\.uploadQueueManager, uploadQueueManager)
+                .environment(\.outcomeQueueManager, outcomeQueueManager)
                 .environment(\.serverMonitor, serverMonitor)
         }
         .modelContainer(sharedModelContainer)
@@ -73,6 +85,10 @@ struct Bin_BrainApp: App {
                 await uploadQueueManager.drain(
                     context: sharedModelContainer.mainContext,
                     using: apiClient
+                )
+                await outcomeQueueManager.drain(
+                    context: sharedModelContainer.mainContext,
+                    apiClient: apiClient
                 )
             }
         }

--- a/Bin Brain/Bin Brain/EnvironmentKeys.swift
+++ b/Bin Brain/Bin Brain/EnvironmentKeys.swift
@@ -35,6 +35,21 @@ extension EnvironmentValues {
     }
 }
 
+// MARK: - OutcomeQueueManager
+
+struct OutcomeQueueManagerKey: EnvironmentKey {
+    static let defaultValue = OutcomeQueueManager()
+}
+
+extension EnvironmentValues {
+    /// The shared `OutcomeQueueManager` for offline-resilient delivery of
+    /// `POST /photos/{id}/outcomes` (Swift2_018).
+    var outcomeQueueManager: OutcomeQueueManager {
+        get { self[OutcomeQueueManagerKey.self] }
+        set { self[OutcomeQueueManagerKey.self] = newValue }
+    }
+}
+
 // MARK: - Embedded in Split View
 
 struct EmbeddedInSplitViewKey: EnvironmentKey {

--- a/Bin Brain/Bin Brain/Models/PendingOutcome.swift
+++ b/Bin Brain/Bin Brain/Models/PendingOutcome.swift
@@ -1,0 +1,92 @@
+// PendingOutcome.swift
+// Bin Brain
+//
+// SwiftData model backing the Swift2_018 offline-outcomes queue. Each row
+// is a serialized `PhotoSuggestionOutcomesRequest` awaiting delivery to
+// `POST /photos/{id}/outcomes`. The queue survives app termination so
+// training signal is not dropped on a flaky network.
+
+import Foundation
+import SwiftData
+
+// MARK: - OutcomeQueueStatus
+
+/// Lifecycle of a queued outcomes POST.
+///
+/// Stored as `Int` rather than `String` so predicate-less filtering (which
+/// SwiftData handles poorly for enums) reads plain integers. The raw values
+/// are frozen — changing them would orphan rows persisted under older apps.
+enum OutcomeQueueStatus: Int, Codable, Sendable {
+    /// Waiting for delivery. Eligible for retry once `nextRetryAt <= now`.
+    case pending = 0
+    /// Currently in flight. Transitory; persisted so cold-launch recovery
+    /// can re-queue stuck rows on relaunch.
+    case sending = 1
+    /// Server accepted the POST (2xx). Retained for Settings visibility
+    /// for 7 days, then swept like any other row past TTL.
+    case delivered = 2
+    /// Permanent failure — either a non-retryable 4xx, 20 retry attempts
+    /// exhausted, or age > 7 days. Surfaced in Settings "Pending Outcomes"
+    /// so the user can see what was lost.
+    case expired = 3
+}
+
+// MARK: - PendingOutcome
+
+/// A single outcomes-POST attempt persisted for retry.
+///
+/// `id` is a client-side UUID used for dedup at the queue level — NOT an
+/// idempotency key against the server (server is append-only per plan).
+/// `payload` is the already-serialized JSON body so retries don't need to
+/// rebuild the outcomes list from state that may have changed on-device.
+@Model
+final class PendingOutcome {
+
+    /// Client-side stable identity. Not sent to the server.
+    @Attribute(.unique) var id: UUID
+
+    /// Server-assigned photo ID — the path component for
+    /// `POST /photos/{id}/outcomes`.
+    var photoId: Int
+
+    /// Serialized JSON body. Frozen at enqueue time; retries re-send verbatim.
+    var payload: Data
+
+    /// Wall-clock time the row was created. Used for the 7-day TTL sweep.
+    var queuedAt: Date
+
+    /// Number of delivery attempts that have failed. 0 on first send;
+    /// increments on every non-2xx retry; emitted to the server via
+    /// `X-Client-Retry-Count` so backend analytics can quantify offline
+    /// pressure.
+    var retryCount: Int
+
+    /// Earliest time the manager may retry this row. Mirrors `queuedAt`
+    /// on the first attempt (no backoff) and advances by
+    /// `OutcomeQueueManager.backoff(retryCount:)` after every failure.
+    var nextRetryAt: Date
+
+    /// Lifecycle position — see `OutcomeQueueStatus`.
+    var status: OutcomeQueueStatus
+
+    /// Last HTTP status or `URLError.code.rawValue`. Surfaced in the
+    /// Settings detail view so users can triage persistent failures.
+    var lastErrorCode: Int?
+
+    /// Creates a `.pending` row for immediate delivery.
+    ///
+    /// - Parameters:
+    ///   - photoId: Server-side photo ID from the preceding `/ingest` call.
+    ///   - payload: Fully-serialized outcomes JSON body.
+    init(photoId: Int, payload: Data) {
+        let now = Date()
+        self.id = UUID()
+        self.photoId = photoId
+        self.payload = payload
+        self.queuedAt = now
+        self.retryCount = 0
+        self.nextRetryAt = now
+        self.status = .pending
+        self.lastErrorCode = nil
+    }
+}

--- a/Bin Brain/Bin Brain/Services/APIClient.swift
+++ b/Bin Brain/Bin Brain/Services/APIClient.swift
@@ -284,6 +284,45 @@ final class APIClient {
         )
     }
 
+    /// Raw variant of `postPhotoSuggestionOutcomes` used by the
+    /// `OutcomeQueueManager` (Swift2_018). Returns the HTTP status code
+    /// directly so the queue can classify retry behaviour without trying
+    /// to decode a response body that may be empty on 4xx/5xx. Throws
+    /// `URLError` on transport failure; never throws for HTTP-layer
+    /// statuses.
+    ///
+    /// - Parameters:
+    ///   - photoId: Server-side photo ID.
+    ///   - body: Already-serialized JSON payload (frozen at enqueue time).
+    ///   - clientRetryCount: Value forwarded as `X-Client-Retry-Count` so
+    ///     the server can log the number of attempts it took to deliver.
+    /// - Returns: The HTTP status code returned by the server.
+    func postPhotoSuggestionOutcomesRaw(
+        photoId: Int,
+        body: Data,
+        clientRetryCount: Int
+    ) async throws -> Int {
+        guard hasAPIKey else { throw APIClientError.missingAPIKey }
+        let urlString = baseURL + "/photos/\(String(photoId).urlPathComponentEncoded)/outcomes"
+        guard let url = URL(string: urlString) else {
+            throw APIClientError.invalidURL(urlString)
+        }
+        var urlRequest = URLRequest(url: url, timeoutInterval: 10)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = body
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("\(max(clientRetryCount, 0))", forHTTPHeaderField: "X-Client-Retry-Count")
+        if let apiKey, shouldAttachKey(requiresAuth: true, probe: false) {
+            urlRequest.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
+
+        let (_, response) = try await session.data(for: urlRequest)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIClientError.unexpectedStatusCode(-1)
+        }
+        return http.statusCode
+    }
+
     /// Creates or upserts an item in the catalogue, optionally linking it to a bin.
     ///
     /// Fields with `nil` values are omitted from the multipart request body.

--- a/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
+++ b/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
@@ -77,28 +77,62 @@ final class OutcomeQueueManager {
 
     // MARK: - Public API
 
-    /// Inserts a new `.pending` row and attempts an immediate delivery.
+    /// Synchronously writes a `.pending` row and returns it.
     ///
-    /// Mirrors the old fire-and-forget latency: the SwiftData write is
-    /// effectively free and the POST runs `async` so the caller returns
-    /// as soon as the row is durable.
+    /// Split out from `enqueue` per QA finding F-2 (PR #23): the previous
+    /// single async method let `confirm()` return before the underlying
+    /// `Task` that wrapped `enqueue` had been scheduled, so an app-kill
+    /// between `confirm()` returning and the Task running would lose
+    /// the outcome entirely. Callers now `persist` synchronously from
+    /// the confirm-path, then fire `deliver` in a detached Task.
     ///
     /// - Parameters:
     ///   - photoId: Server photo ID the outcomes belong to.
     ///   - payload: Already-encoded outcomes JSON body.
     ///   - context: Main-thread SwiftData context.
-    ///   - apiClient: Client used to issue the POST.
+    /// - Returns: The persisted row, ready to hand to `deliver`.
+    @discardableResult
+    func persist(
+        photoId: Int,
+        payload: Data,
+        context: ModelContext
+    ) -> PendingOutcome {
+        let row = PendingOutcome(photoId: photoId, payload: payload)
+        context.insert(row)
+        save(context)
+        refreshCounts(context: context)
+        return row
+    }
+
+    /// Attempts immediate delivery of a previously-persisted row. Safe
+    /// to run fire-and-forget: exceptions are caught, status transitions
+    /// happen against the persisted row, and the counts refresh after.
+    ///
+    /// Exposed so the confirm-path can separate the durable write
+    /// (`persist`) from the network attempt, but still available as a
+    /// single-step convenience via `enqueue`.
+    func deliver(
+        _ row: PendingOutcome,
+        context: ModelContext,
+        apiClient: APIClient
+    ) async {
+        await attemptDelivery(row, context: context, apiClient: apiClient)
+    }
+
+    /// Convenience wrapper that persists and attempts delivery in one call.
+    ///
+    /// Preserved so existing tests (and non-confirm callers that don't
+    /// need the split) keep a single entry point. F-2's invariant —
+    /// "row durable before confirm returns" — is upheld at the VM level
+    /// by calling `persist` directly and spawning `deliver` in a Task.
     func enqueue(
         photoId: Int,
         payload: Data,
         context: ModelContext,
         apiClient: APIClient
     ) async {
-        let row = PendingOutcome(photoId: photoId, payload: payload)
-        context.insert(row)
-        save(context)
-        refreshCounts(context: context)
-        await deliver(row, context: context, apiClient: apiClient)
+        let row = persist(photoId: photoId, payload: payload, context: context)
+        await attemptDelivery(row, context: context, apiClient: apiClient)
     }
 
     /// Processes every row whose `nextRetryAt <= now`, then sweeps TTL.
@@ -245,7 +279,7 @@ final class OutcomeQueueManager {
 
     // MARK: - Delivery
 
-    private func deliver(
+    private func attemptDelivery(
         _ row: PendingOutcome,
         context: ModelContext,
         apiClient: APIClient
@@ -315,9 +349,25 @@ final class OutcomeQueueManager {
             return
         }
         var touched = false
-        for row in all where row.queuedAt < cutoff && row.status != .expired && row.status != .delivered {
-            row.status = .expired
-            touched = true
+        for row in all where row.queuedAt < cutoff {
+            switch row.status {
+            case .pending, .sending:
+                // Surface the row in the Settings dead-letter so users
+                // can see what failed. Leaves `.expired` rows alone —
+                // dismissal is an explicit user action.
+                row.status = .expired
+                touched = true
+            case .delivered:
+                // F-4 (QA PR #23): delivered rows were retained forever.
+                // Delete them after the 7-day TTL so the store stays
+                // bounded. The user-visible "Delivered (last 7 days)"
+                // count in Settings is now accurate by construction.
+                context.delete(row)
+                touched = true
+            case .expired:
+                // Keep — user will dismiss explicitly.
+                break
+            }
         }
         if touched {
             save(context)

--- a/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
+++ b/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
@@ -1,0 +1,335 @@
+// OutcomeQueueManager.swift
+// Bin Brain
+//
+// Offline-outcomes queue for Swift2_018. Persists every
+// `POST /photos/{id}/outcomes` attempt as a `PendingOutcome` row and
+// retries on a capped exponential schedule until the server accepts the
+// payload, the request ages out of the 7-day TTL, or 20 retries are
+// exhausted.
+//
+// The manager itself holds no long-lived references to a `ModelContext`
+// or `APIClient`; callers pass both on every public method. This mirrors
+// `UploadQueueManager` and keeps the manager unit-testable with an
+// in-memory SwiftData container and a mocked URLSession.
+
+import Foundation
+import Network
+import OSLog
+import Observation
+import SwiftData
+#if canImport(UIKit)
+import UIKit
+#endif
+
+private let logger = Logger(subsystem: "com.binbrain.app", category: "OutcomeQueueManager")
+
+// MARK: - OutcomeQueueManager
+
+/// Drains the `PendingOutcome` queue with capped exponential backoff.
+///
+/// Not `@MainActor`-isolated: the `Observable` state is read by SwiftUI
+/// views on the main thread but the actual drain loop runs wherever the
+/// caller awaits. SwiftData `ModelContext` is assumed to be a main-thread
+/// context — production callers pass `sharedModelContainer.mainContext`.
+@Observable
+final class OutcomeQueueManager {
+
+    // MARK: - Tunables
+
+    /// First-retry delay in seconds. Subsequent retries double.
+    static let firstRetryDelay: TimeInterval = 30
+
+    /// Cap on the backoff interval — 1 hour.
+    static let maxRetryDelay: TimeInterval = 3600
+
+    /// Maximum number of retries before a row is forced `.expired`.
+    static let maxRetryCount: Int = 20
+
+    /// TTL beyond which a row is expired regardless of status. 7 days.
+    static let maxAge: TimeInterval = 7 * 24 * 60 * 60
+
+    // MARK: - Observable counts (for Settings)
+
+    private(set) var pendingCount: Int = 0
+    private(set) var deliveredCount: Int = 0
+    private(set) var expiredCount: Int = 0
+
+    // MARK: - Test seams
+
+    /// Overridable clock so tests can exercise time-dependent paths.
+    var now: () -> Date = { Date() }
+
+    // MARK: - Backoff
+
+    /// Returns the retry delay (seconds) for the Nth failed attempt.
+    ///
+    /// Schedule: 30s, 1m, 2m, 4m, …, clamped to 1h. `retryCount = 0` returns
+    /// `0` (first attempt fires immediately); negative values also return 0
+    /// as a defensive fallback for any future corrupt persistence.
+    static func backoff(retryCount: Int) -> TimeInterval {
+        guard retryCount > 0 else { return 0 }
+        // 30 * 2^(n-1). Compute via floating point and clamp — avoids the
+        // `Int` overflow that would hit around retry 58 on 64-bit and keeps
+        // the cap expression compact.
+        let raw = firstRetryDelay * pow(2.0, Double(retryCount - 1))
+        return min(raw, maxRetryDelay)
+    }
+
+    // MARK: - Public API
+
+    /// Inserts a new `.pending` row and attempts an immediate delivery.
+    ///
+    /// Mirrors the old fire-and-forget latency: the SwiftData write is
+    /// effectively free and the POST runs `async` so the caller returns
+    /// as soon as the row is durable.
+    ///
+    /// - Parameters:
+    ///   - photoId: Server photo ID the outcomes belong to.
+    ///   - payload: Already-encoded outcomes JSON body.
+    ///   - context: Main-thread SwiftData context.
+    ///   - apiClient: Client used to issue the POST.
+    func enqueue(
+        photoId: Int,
+        payload: Data,
+        context: ModelContext,
+        apiClient: APIClient
+    ) async {
+        let row = PendingOutcome(photoId: photoId, payload: payload)
+        context.insert(row)
+        save(context)
+        refreshCounts(context: context)
+        await deliver(row, context: context, apiClient: apiClient)
+    }
+
+    /// Processes every row whose `nextRetryAt <= now`, then sweeps TTL.
+    ///
+    /// Intended triggers: `NWPathMonitor` transition to `.satisfied`,
+    /// `UIApplication.willEnterForegroundNotification`, and app launch.
+    /// Expired rows are identified first so the sweep doesn't waste
+    /// network on deliveries that would just be dropped.
+    func drain(
+        context: ModelContext,
+        apiClient: APIClient
+    ) async {
+        expireAged(context: context)
+        let nowDate = now()
+        let ready: [PendingOutcome]
+        do {
+            let all = try context.fetch(FetchDescriptor<PendingOutcome>())
+            ready = all
+                .filter { $0.status == .pending && $0.nextRetryAt <= nowDate }
+                .sorted { $0.queuedAt < $1.queuedAt }
+        } catch {
+            logger.error("[OUTCOMES] drain fetch failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+        for row in ready {
+            await deliver(row, context: context, apiClient: apiClient)
+        }
+    }
+
+    /// Forces every `.pending` row to attempt delivery NOW, ignoring
+    /// `nextRetryAt`. Invoked from the Settings "Retry all" action.
+    func retryAll(
+        context: ModelContext,
+        apiClient: APIClient
+    ) async {
+        expireAged(context: context)
+        let rows: [PendingOutcome]
+        do {
+            let all = try context.fetch(FetchDescriptor<PendingOutcome>())
+            rows = all.filter { $0.status == .pending }.sorted { $0.queuedAt < $1.queuedAt }
+        } catch {
+            logger.error("[OUTCOMES] retryAll fetch failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+        for row in rows {
+            await deliver(row, context: context, apiClient: apiClient)
+        }
+    }
+
+    /// Removes a single `.expired` row. Called from the Settings detail
+    /// view's "Dismiss" action.
+    func dismiss(_ outcome: PendingOutcome, context: ModelContext) {
+        context.delete(outcome)
+        save(context)
+        refreshCounts(context: context)
+    }
+
+    /// Recomputes `pendingCount`, `deliveredCount`, and `expiredCount`
+    /// from the persisted rows. Called after every mutation.
+    func refreshCounts(context: ModelContext) {
+        let all: [PendingOutcome]
+        do {
+            all = try context.fetch(FetchDescriptor<PendingOutcome>())
+        } catch {
+            logger.error("[OUTCOMES] refreshCounts fetch failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+        pendingCount = all.filter { $0.status == .pending }.count
+        deliveredCount = all.filter { $0.status == .delivered }.count
+        expiredCount = all.filter { $0.status == .expired }.count
+    }
+
+    // MARK: - Production wiring (not exercised in unit tests)
+
+    #if canImport(UIKit)
+    private var pathMonitor: NWPathMonitor?
+    private var foregroundObserver: NSObjectProtocol?
+    private var monitorQueue: DispatchQueue?
+    /// Context + client stashed on self so the NWPathMonitor and
+    /// NotificationCenter closures don't need to capture parameters
+    /// directly — `ModelContext` is non-Sendable and capturing it in a
+    /// `@Sendable` closure is a Swift-6 error. Accessed only from the
+    /// main actor via `startMonitoring` / `runMonitoredDrain`.
+    private var monitoringContext: ModelContext?
+    private var monitoringAPIClient: APIClient?
+
+    /// Starts the NWPathMonitor + willEnterForeground observers.
+    ///
+    /// Called once from `Bin_BrainApp` so the queue auto-drains on network
+    /// recovery or when the app resumes. Idempotent — calling twice keeps
+    /// the existing monitors.
+    @MainActor
+    func startMonitoring(
+        context: ModelContext,
+        apiClient: APIClient
+    ) {
+        guard pathMonitor == nil else { return }
+        monitoringContext = context
+        monitoringAPIClient = apiClient
+        let queue = DispatchQueue(label: "com.binbrain.outcome-queue.path")
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard path.status == .satisfied else { return }
+            Task { @MainActor [weak self] in
+                await self?.runMonitoredDrain()
+            }
+        }
+        monitor.start(queue: queue)
+        pathMonitor = monitor
+        monitorQueue = queue
+
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.runMonitoredDrain()
+            }
+        }
+    }
+
+    /// Tears down the monitors. Primarily for tests and future multi-user
+    /// support — production calls `startMonitoring` once at launch.
+    @MainActor
+    func stopMonitoring() {
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        monitorQueue = nil
+        if let foregroundObserver {
+            NotificationCenter.default.removeObserver(foregroundObserver)
+        }
+        foregroundObserver = nil
+        monitoringContext = nil
+        monitoringAPIClient = nil
+    }
+
+    @MainActor
+    private func runMonitoredDrain() async {
+        guard let monitoringContext, let monitoringAPIClient else { return }
+        await drain(context: monitoringContext, apiClient: monitoringAPIClient)
+    }
+    #endif
+
+    // MARK: - Delivery
+
+    private func deliver(
+        _ row: PendingOutcome,
+        context: ModelContext,
+        apiClient: APIClient
+    ) async {
+        row.status = .sending
+        save(context)
+
+        let status: Int?
+        var networkFailure = false
+        do {
+            status = try await apiClient.postPhotoSuggestionOutcomesRaw(
+                photoId: row.photoId,
+                body: row.payload,
+                clientRetryCount: row.retryCount
+            )
+        } catch let urlError as URLError {
+            row.lastErrorCode = urlError.code.rawValue
+            status = nil
+            networkFailure = true
+            logger.error("[OUTCOMES] transport failure for photo \(row.photoId, privacy: .public): \(urlError.localizedDescription, privacy: .private)")
+        } catch {
+            row.lastErrorCode = nil
+            status = nil
+            networkFailure = true
+            logger.error("[OUTCOMES] unexpected error for photo \(row.photoId, privacy: .public): \(error.localizedDescription, privacy: .private)")
+        }
+
+        classify(row: row, status: status, networkFailure: networkFailure)
+        save(context)
+        refreshCounts(context: context)
+    }
+
+    private func classify(row: PendingOutcome, status: Int?, networkFailure: Bool) {
+        if let status {
+            row.lastErrorCode = status
+            if (200...299).contains(status) {
+                row.status = .delivered
+                return
+            }
+            // 408 and 429 are transient even though they fall in 4xx.
+            let retryableHTTP = status == 408 || status == 429 || (500...599).contains(status)
+            if !retryableHTTP {
+                row.status = .expired
+                return
+            }
+        }
+        // Retryable (5xx, 408/429, or transport error).
+        row.retryCount += 1
+        if row.retryCount >= Self.maxRetryCount {
+            row.status = .expired
+            return
+        }
+        row.status = .pending
+        row.nextRetryAt = now().addingTimeInterval(Self.backoff(retryCount: row.retryCount))
+        _ = networkFailure // logged above; explicitly ignored here
+    }
+
+    // MARK: - Sweeps
+
+    private func expireAged(context: ModelContext) {
+        let cutoff = now().addingTimeInterval(-Self.maxAge)
+        let all: [PendingOutcome]
+        do {
+            all = try context.fetch(FetchDescriptor<PendingOutcome>())
+        } catch {
+            logger.error("[OUTCOMES] expireAged fetch failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+        var touched = false
+        for row in all where row.queuedAt < cutoff && row.status != .expired && row.status != .delivered {
+            row.status = .expired
+            touched = true
+        }
+        if touched {
+            save(context)
+            refreshCounts(context: context)
+        }
+    }
+
+    private func save(_ context: ModelContext) {
+        do {
+            try context.save()
+        } catch {
+            logger.error("[OUTCOMES] context.save failed: \(error.localizedDescription, privacy: .private)")
+        }
+    }
+}

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Observation
 import OSLog
+import SwiftData
 import UIKit
 
 // MARK: - ChipOrigin
@@ -159,6 +160,19 @@ final class SuggestionReviewViewModel {
     /// treats empty as "not yet ready" and aborts the call.
     var binId: String = ""
 
+    // MARK: - Swift2_018 Outcomes Queue
+
+    /// Optional reference to the durable outcomes queue. When the view
+    /// injects this alongside `outcomeQueueContext`, `confirm()` enqueues
+    /// the outcomes payload instead of firing it as a one-shot detached
+    /// `Task`. When either is `nil`, the legacy fire-and-forget path
+    /// runs unchanged so the 30+ existing `confirm(...)` test call sites
+    /// keep passing.
+    var outcomeQueueManager: OutcomeQueueManager?
+
+    /// Main-thread `ModelContext` paired with `outcomeQueueManager`.
+    var outcomeQueueContext: ModelContext?
+
     // MARK: - Swift2_014 Outcomes State
 
     /// Photo identifier under review, threaded from `AnalysisViewModel.lastPhotoId`.
@@ -243,8 +257,11 @@ final class SuggestionReviewViewModel {
 
     /// Advances `editableSuggestions[id].outcomeState` per the tap cycle and
     /// keeps `included` in sync (only `.accepted` rows fire the upsert
-    /// pipeline). Unknown ids are no-ops.
+    /// pipeline). Unknown ids are no-ops. Also a no-op while `isConfirming`
+    /// — defence-in-depth for SEC-22-2; the view's `.disabled` already
+    /// blocks the taps in practice.
     func cycleOutcome(id: Int) {
+        guard !isConfirming else { return }
         guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }) else { return }
         let newState = editableSuggestions[idx].outcomeState.next()
         editableSuggestions[idx].outcomeState = newState
@@ -776,6 +793,30 @@ final class SuggestionReviewViewModel {
             decisions: decisions
         )
         let pid = photoId
+
+        // Swift2_018 — preferred path. The queue persists the payload so
+        // network or 5xx failures retry on backoff, NWPathMonitor, and
+        // foreground transitions instead of being silently dropped.
+        if let queue = outcomeQueueManager, let context = outcomeQueueContext {
+            do {
+                let body = try JSONEncoder.binBrain.encode(request)
+                Task { @MainActor in
+                    await queue.enqueue(
+                        photoId: pid,
+                        payload: body,
+                        context: context,
+                        apiClient: apiClient
+                    )
+                }
+            } catch {
+                logger.error("[OUTCOMES] payload encode failed (queue path): \(error.localizedDescription, privacy: .private)")
+            }
+            return
+        }
+
+        // Legacy fire-and-forget path — kept for tests that pre-date the
+        // queue. Production view sites set `outcomeQueueManager` and
+        // `outcomeQueueContext`, which short-circuits this branch.
         Task { [apiClient, pid, request] in
             do {
                 _ = try await apiClient.postPhotoSuggestionOutcomes(photoId: pid, request: request)

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -797,16 +797,19 @@ final class SuggestionReviewViewModel {
         // Swift2_018 — preferred path. The queue persists the payload so
         // network or 5xx failures retry on backoff, NWPathMonitor, and
         // foreground transitions instead of being silently dropped.
+        //
+        // F-2 (QA PR #23 review): write the row synchronously BEFORE
+        // spawning the POST task. Wrapping the whole enqueue in a `Task`
+        // let confirm() return before the SwiftData insert ran, so an
+        // app-kill between return and the Task running would drop the
+        // outcome. `persist` is synchronous (<1ms) so confirm() is still
+        // effectively fire-and-forget from the user's perspective.
         if let queue = outcomeQueueManager, let context = outcomeQueueContext {
             do {
                 let body = try JSONEncoder.binBrain.encode(request)
+                let row = queue.persist(photoId: pid, payload: body, context: context)
                 Task { @MainActor in
-                    await queue.enqueue(
-                        photoId: pid,
-                        payload: body,
-                        context: context,
-                        apiClient: apiClient
-                    )
+                    await queue.deliver(row, context: context, apiClient: apiClient)
                 }
             } catch {
                 logger.error("[OUTCOMES] payload encode failed (queue path): \(error.localizedDescription, privacy: .private)")

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -38,6 +38,7 @@ struct BinDetailView: View {
     @State private var viewModel = BinDetailViewModel()
     @Environment(\.apiClient) private var apiClient
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.outcomeQueueManager) private var outcomeQueueManager
     @State private var showAddItem = false
     @State private var showCamera = false
     @State private var sortOrder: SortOrder = .name
@@ -348,6 +349,13 @@ struct BinDetailView: View {
                 escalateModelAndReSuggest()
             } : nil
         )
+        // Swift2_018 — inject the durable outcomes queue + context so
+        // confirm() persists each outcomes POST instead of firing it as a
+        // one-shot detached Task. Both must be set before confirm() runs.
+        .onAppear {
+            reviewViewModel.outcomeQueueManager = outcomeQueueManager
+            reviewViewModel.outcomeQueueContext = modelContext
+        }
         // Same fix as BinsListView: observe phase on the visible view, not the background AnalysisProgressView.
         .onChange(of: analysisViewModel.phase) { _, newPhase in
             guard case .complete = newPhase, navigatedOnPreliminary else { return }

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -46,6 +46,7 @@ struct BinsListView: View {
     @State private var viewModel = BinsListViewModel()
     @Environment(\.apiClient) private var apiClient
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.outcomeQueueManager) private var outcomeQueueManager
     @Environment(\.embeddedInSplitView) private var embeddedInSplitView
 
     // Cataloging flow
@@ -283,6 +284,13 @@ struct BinsListView: View {
                 escalateModelAndReSuggest()
             } : nil
         )
+        // Swift2_018 — inject the durable outcomes queue + context so
+        // confirm() persists each outcomes POST instead of firing it as a
+        // one-shot detached Task. Both must be set before confirm() runs.
+        .onAppear {
+            reviewViewModel.outcomeQueueManager = outcomeQueueManager
+            reviewViewModel.outcomeQueueContext = modelContext
+        }
         // AnalysisProgressView.onChange(of: phase) is unreliable when that view is
         // in the NavigationStack background (non-visible destination). Observe here
         // on the active visible view so server suggestions always land.

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -368,6 +368,12 @@ struct SuggestionReviewView: View {
                 .contentTransition(.symbolEffect(.replace))
         }
         .buttonStyle(.plain)
+        // SEC-22-2 (LOW from PR #22 SEC review): tapping the chip mid-confirm
+        // races with the in-flight upsert loop — the state mutation can slip
+        // between confirmed and un-confirmed reads. Disabling while
+        // `isConfirming` closes that window without blocking any legitimate
+        // pre-confirm interaction.
+        .disabled(viewModel.isConfirming)
         .accessibilityLabel(Self.chipAccessibilityLabel(
             name: suggestion.editedName,
             state: suggestion.outcomeState

--- a/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
+++ b/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @State private var viewModel = SettingsViewModel()
     @Environment(\.apiClient) private var apiClient
     @Environment(\.uploadQueueManager) private var uploadQueueManager
+    @Environment(\.outcomeQueueManager) private var outcomeQueueManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.embeddedInSplitView) private var embeddedInSplitView
 
@@ -55,6 +56,7 @@ struct SettingsView: View {
             searchSection
             catalogingSection
             uploadQueueSection
+            outcomeQueueSection
         }
         .navigationTitle("Settings")
         .task {
@@ -384,5 +386,88 @@ struct SettingsView: View {
                 uploadQueueManager.clearQueue(context: modelContext)
             }
         }
+    }
+
+    // MARK: - Outcome Queue (Swift2_018)
+
+    @ViewBuilder
+    private var outcomeQueueSection: some View {
+        Section("Pending Outcomes") {
+            Text("Pending: \(outcomeQueueManager.pendingCount)")
+            Text("Delivered: \(outcomeQueueManager.deliveredCount)")
+                .foregroundStyle(.secondary)
+            Text("Expired: \(outcomeQueueManager.expiredCount)")
+                .foregroundStyle(outcomeQueueManager.expiredCount > 0 ? .orange : .secondary)
+
+            NavigationLink("View expired outcomes") {
+                ExpiredOutcomesView()
+            }
+            .disabled(outcomeQueueManager.expiredCount == 0)
+
+            Button("Retry all") {
+                Task {
+                    await outcomeQueueManager.retryAll(
+                        context: modelContext,
+                        apiClient: apiClient
+                    )
+                }
+            }
+            .disabled(outcomeQueueManager.pendingCount == 0)
+        }
+        .task {
+            outcomeQueueManager.refreshCounts(context: modelContext)
+        }
+    }
+}
+
+// MARK: - ExpiredOutcomesView
+
+/// Detail screen for inspecting and dismissing `.expired` outcomes.
+///
+/// Reads rows directly via `@Query` so the list updates automatically when
+/// the queue manager flips a row to `.expired` or the user dismisses one.
+private struct ExpiredOutcomesView: View {
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.outcomeQueueManager) private var outcomeQueueManager
+    @Query(filter: #Predicate<PendingOutcome> { $0.status.rawValue == 3 },
+           sort: \PendingOutcome.queuedAt,
+           order: .reverse)
+    private var expired: [PendingOutcome]
+
+    var body: some View {
+        List {
+            if expired.isEmpty {
+                ContentUnavailableView(
+                    "No expired outcomes",
+                    systemImage: "checkmark.seal",
+                    description: Text("Outcomes that the server permanently rejected or that timed out after 7 days appear here.")
+                )
+            } else {
+                ForEach(expired) { row in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Photo #\(row.photoId)")
+                            .font(.headline)
+                        Text("Queued: \(row.queuedAt.formatted(date: .abbreviated, time: .shortened))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("Retries: \(row.retryCount)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let code = row.lastErrorCode {
+                            Text("Last error code: \(code)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button("Dismiss", role: .destructive) {
+                            outcomeQueueManager.dismiss(row, context: modelContext)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Expired Outcomes")
     }
 }

--- a/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
@@ -329,6 +329,76 @@ final class OutcomeQueueManagerTests: XCTestCase {
         XCTAssertTrue(rows.isEmpty, "Dismiss must remove the expired row from storage")
     }
 
+    // MARK: - F-2: persist is synchronous
+
+    /// F-2 (QA PR #23): `persist(...)` writes the row to SwiftData
+    /// synchronously — no await, no Task scheduling. This is what lets
+    /// `SuggestionReviewViewModel.confirm()` return with the row durable
+    /// so an app-kill cannot drop the outcome.
+    func testPersistIsSynchronousAndRowIsImmediatelyQueryable() throws {
+        let row = sut.persist(photoId: 99, payload: samplePayload, context: context)
+
+        // Same tick: fetch and find it.
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rows.count, 1,
+                       "persist must synchronously commit the row — no awaits in the write path")
+        XCTAssertEqual(rows.first?.id, row.id)
+        XCTAssertEqual(rows.first?.photoId, 99)
+        XCTAssertEqual(rows.first?.status, .pending)
+    }
+
+    // MARK: - F-4: delivered-row TTL sweep
+
+    /// F-4 (QA PR #23): delivered rows used to accumulate forever
+    /// because `expireAged` excluded `.delivered`. The TTL sweep now
+    /// deletes delivered rows past the 7-day cutoff so the store stays
+    /// bounded without a separate janitor.
+    func testExpirationSweepDeletesDeliveredRowsPastTTL() async throws {
+        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
+        let freshDelivered = PendingOutcome(photoId: 1, payload: samplePayload)
+        freshDelivered.status = .delivered
+        let staleDelivered = PendingOutcome(photoId: 2, payload: samplePayload)
+        staleDelivered.status = .delivered
+        staleDelivered.queuedAt = eightDaysAgo
+        context.insert(freshDelivered)
+        context.insert(staleDelivered)
+        try context.save()
+
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let ids = Set(rows.map(\.photoId))
+        XCTAssertTrue(ids.contains(1),
+                      "Fresh delivered row (< 7 days) must be retained")
+        XCTAssertFalse(ids.contains(2),
+                       "Stale delivered row (> 7 days) must be deleted, not merely flipped to .expired")
+    }
+
+    /// Expired rows stay put — dismissal is an explicit user action,
+    /// not a TTL behaviour.
+    func testExpirationSweepLeavesExpiredRowsAlone() async throws {
+        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
+        let staleExpired = PendingOutcome(photoId: 3, payload: samplePayload)
+        staleExpired.status = .expired
+        staleExpired.queuedAt = eightDaysAgo
+        context.insert(staleExpired)
+        try context.save()
+
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rows.first?.status, .expired,
+                       "Expired rows persist until the user dismisses them explicitly")
+    }
+
     // MARK: - Observable counts
 
     func testCountsReflectPersistedRows() async throws {

--- a/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
@@ -1,0 +1,351 @@
+// OutcomeQueueManagerTests.swift
+// Bin BrainTests
+//
+// XCTest coverage for the Swift2_018 offline-outcomes queue manager.
+// All tests use a custom `URLProtocol` subclass to intercept every request
+// — no real socket opens, no risk of polluting the production outcomes table.
+
+import XCTest
+import SwiftData
+@testable import Bin_Brain
+
+// MARK: - URL protocol mock
+
+/// Distinct name (not `MockURLProtocol`) to avoid link-time collisions with
+/// other test suites that install their own interceptors.
+final class OutcomeQueueMockURLProtocol: URLProtocol {
+    // Thread-safe handler storage so the URL loading thread can read the
+    // handler while the test thread mutates it between scenarios.
+    private static let handlerLock = NSLock()
+    nonisolated(unsafe) private static var _handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func setHandler(_ handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        _handler = handler
+    }
+
+    static func currentHandler() -> ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        return _handler
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.currentHandler() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - OutcomeQueueManagerTests
+
+@MainActor
+final class OutcomeQueueManagerTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var sut: OutcomeQueueManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let schema = Schema([PendingOutcome.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: config)
+        context = ModelContext(container)
+        sut = OutcomeQueueManager()
+    }
+
+    override func tearDown() async throws {
+        OutcomeQueueMockURLProtocol.setHandler(nil)
+        sut = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockAPIClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        OutcomeQueueMockURLProtocol.setHandler(handler)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [OutcomeQueueMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func mockResponse(statusCode: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private var samplePayload: Data { Data("{\"vision_model\":\"test\"}".utf8) }
+
+    // MARK: - enqueue happy path
+
+    func testEnqueueSuccessMarksRowDelivered() async throws {
+        var capturedHeader: String?
+        let client = makeMockAPIClient { [self] request in
+            capturedHeader = request.value(forHTTPHeaderField: "X-Client-Retry-Count")
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.enqueue(photoId: 7, payload: samplePayload, context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.status, .delivered,
+                       "2xx response must mark the row as delivered (mark+sweep)")
+        XCTAssertEqual(rows.first?.photoId, 7)
+        XCTAssertEqual(capturedHeader, "0",
+                       "First-attempt POST must emit X-Client-Retry-Count: 0")
+    }
+
+    // MARK: - 5xx leaves row pending with incremented retryCount
+
+    func testEnqueueServer500LeavesRowPendingAndIncrementsRetryCount() async throws {
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 500, for: request), Data("{}".utf8))
+        }
+
+        let before = Date()
+        await sut.enqueue(photoId: 7, payload: samplePayload, context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.status, .pending, "5xx must leave the row pending for retry")
+        XCTAssertEqual(row.retryCount, 1, "First 5xx increments retryCount to 1")
+        XCTAssertEqual(row.lastErrorCode, 500, "HTTP status recorded for Settings detail view")
+        XCTAssertGreaterThan(row.nextRetryAt, before,
+                             "Backoff must push nextRetryAt into the future")
+    }
+
+    // MARK: - 422 is non-retryable → .expired
+
+    func testEnqueue422MarksRowExpiredImmediately() async throws {
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 422, for: request), Data("{}".utf8))
+        }
+
+        await sut.enqueue(photoId: 1, payload: samplePayload, context: context, apiClient: client)
+
+        let row = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(row.status, .expired,
+                       "Validator 422 is a client bug — retrying is futile")
+        XCTAssertEqual(row.lastErrorCode, 422)
+    }
+
+    // MARK: - 408 / 429 are retryable
+
+    func testEnqueue408LeavesRowPending() async throws {
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 408, for: request), Data())
+        }
+
+        await sut.enqueue(photoId: 1, payload: samplePayload, context: context, apiClient: client)
+
+        let row = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(row.status, .pending,
+                       "408 Request Timeout is transient — must stay pending for retry")
+        XCTAssertEqual(row.retryCount, 1)
+        XCTAssertEqual(row.lastErrorCode, 408)
+    }
+
+    func testEnqueue429LeavesRowPending() async throws {
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 429, for: request), Data())
+        }
+
+        await sut.enqueue(photoId: 1, payload: samplePayload, context: context, apiClient: client)
+
+        let row = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(row.status, .pending,
+                       "429 Too Many Requests is transient — client-side backoff covers it")
+        XCTAssertEqual(row.retryCount, 1)
+    }
+
+    // MARK: - Network (URLError) is retryable
+
+    func testEnqueueNetworkErrorLeavesRowPending() async throws {
+        let client = makeMockAPIClient { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        await sut.enqueue(photoId: 1, payload: samplePayload, context: context, apiClient: client)
+
+        let row = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(row.status, .pending,
+                       "Transport failure is the canonical retry case — queue keeps it for NWPathMonitor sweep")
+        XCTAssertEqual(row.retryCount, 1)
+    }
+
+    // MARK: - Retry count echoed on subsequent attempts
+
+    func testDrainEmitsIncrementedRetryCountHeader() async throws {
+        // Seed a row that failed once already.
+        let row = PendingOutcome(photoId: 11, payload: samplePayload)
+        row.retryCount = 3
+        row.status = .pending
+        row.nextRetryAt = Date().addingTimeInterval(-1) // ready to retry now
+        context.insert(row)
+        try context.save()
+
+        var capturedHeader: String?
+        let client = makeMockAPIClient { [self] request in
+            capturedHeader = request.value(forHTTPHeaderField: "X-Client-Retry-Count")
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        XCTAssertEqual(capturedHeader, "3",
+                       "Retry attempt must echo the accumulated retry count to the server")
+        let refreshed = try context.fetch(FetchDescriptor<PendingOutcome>()).first
+        XCTAssertEqual(refreshed?.status, .delivered)
+    }
+
+    // MARK: - 20-retry cap
+
+    func testTwentyFailedRetriesForceExpired() async throws {
+        let row = PendingOutcome(photoId: 11, payload: samplePayload)
+        row.retryCount = 19
+        row.nextRetryAt = Date().addingTimeInterval(-1)
+        context.insert(row)
+        try context.save()
+
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 500, for: request), Data())
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        let refreshed = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(refreshed.retryCount, 20)
+        XCTAssertEqual(refreshed.status, .expired,
+                       "20th consecutive failure must force .expired — bounded even if network is permanently hostile")
+    }
+
+    // MARK: - 7-day TTL expiration sweep
+
+    func testExpirationSweepMarksOldRowsExpired() async throws {
+        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
+        let fresh = PendingOutcome(photoId: 1, payload: samplePayload)
+        let stale = PendingOutcome(photoId: 2, payload: samplePayload)
+        stale.queuedAt = eightDaysAgo
+        context.insert(fresh)
+        context.insert(stale)
+        try context.save()
+
+        let client = makeMockAPIClient { [self] request in
+            // The stale row never hits the wire — it is expired before any
+            // POST. The fresh row has nextRetryAt == queuedAt ≈ now, so it
+            // IS eligible and will be delivered successfully; this test
+            // only asserts the stale row's expiry behaviour.
+            (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let staleRow = try XCTUnwrap(rows.first(where: { $0.photoId == 2 }))
+        XCTAssertEqual(staleRow.status, .expired,
+                       "Row older than 7 days must be expired on sweep")
+    }
+
+    // MARK: - retryAll forces pending rows regardless of nextRetryAt
+
+    func testRetryAllIgnoresNextRetryAt() async throws {
+        let row = PendingOutcome(photoId: 1, payload: samplePayload)
+        row.retryCount = 2
+        row.nextRetryAt = Date().addingTimeInterval(600) // 10m in the future
+        context.insert(row)
+        try context.save()
+
+        let client = makeMockAPIClient { [self] request in
+            (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.retryAll(context: context, apiClient: client)
+
+        let refreshed = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(refreshed.status, .delivered,
+                       "retryAll must bypass nextRetryAt so user-initiated retries fire immediately")
+    }
+
+    // MARK: - drain skips rows not yet due
+
+    func testDrainSkipsRowsBeforeNextRetryAt() async throws {
+        let row = PendingOutcome(photoId: 1, payload: samplePayload)
+        row.retryCount = 2
+        row.nextRetryAt = Date().addingTimeInterval(600) // 10m in the future
+        context.insert(row)
+        try context.save()
+
+        var posts = 0
+        let client = makeMockAPIClient { [self] request in
+            posts += 1
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        XCTAssertEqual(posts, 0,
+                       "drain must respect nextRetryAt — user-visible retryAll is the escape hatch")
+        let refreshed = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(refreshed.status, .pending)
+    }
+
+    // MARK: - dismiss deletes an expired row
+
+    func testDismissDeletesExpiredRow() async throws {
+        let row = PendingOutcome(photoId: 1, payload: samplePayload)
+        row.status = .expired
+        context.insert(row)
+        try context.save()
+
+        sut.dismiss(row, context: context)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertTrue(rows.isEmpty, "Dismiss must remove the expired row from storage")
+    }
+
+    // MARK: - Observable counts
+
+    func testCountsReflectPersistedRows() async throws {
+        let pending = PendingOutcome(photoId: 1, payload: samplePayload)
+        let delivered = PendingOutcome(photoId: 2, payload: samplePayload)
+        delivered.status = .delivered
+        let expired = PendingOutcome(photoId: 3, payload: samplePayload)
+        expired.status = .expired
+        context.insert(pending)
+        context.insert(delivered)
+        context.insert(expired)
+        try context.save()
+
+        sut.refreshCounts(context: context)
+
+        XCTAssertEqual(sut.pendingCount, 1)
+        XCTAssertEqual(sut.deliveredCount, 1)
+        XCTAssertEqual(sut.expiredCount, 1)
+    }
+}

--- a/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
+++ b/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
@@ -1,0 +1,116 @@
+// PendingOutcomeTests.swift
+// Bin BrainTests
+//
+// SwiftData CRUD coverage for the Swift2_018 offline-outcomes queue model.
+// All tests use an in-memory ModelContainer to avoid touching the file
+// system or any device state.
+
+import XCTest
+import SwiftData
+@testable import Bin_Brain
+
+final class PendingOutcomeTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+
+    override func setUpWithError() throws {
+        let schema = Schema([PendingOutcome.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: config)
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        context = nil
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultInitialisationSetsExpectedValues() {
+        let before = Date()
+        let payload = Data("{\"hello\":\"world\"}".utf8)
+        let row = PendingOutcome(photoId: 42, payload: payload)
+        let after = Date()
+
+        XCTAssertEqual(row.photoId, 42)
+        XCTAssertEqual(row.payload, payload)
+        XCTAssertEqual(row.retryCount, 0)
+        XCTAssertEqual(row.status, .pending)
+        XCTAssertNil(row.lastErrorCode)
+        XCTAssertGreaterThanOrEqual(row.queuedAt, before)
+        XCTAssertLessThanOrEqual(row.queuedAt, after)
+        XCTAssertEqual(row.nextRetryAt, row.queuedAt,
+                       "First attempt has no backoff — nextRetryAt mirrors queuedAt")
+    }
+
+    // MARK: - UUID uniqueness
+
+    func testIdsAreUniquePerInstance() {
+        let a = PendingOutcome(photoId: 1, payload: Data([0]))
+        let b = PendingOutcome(photoId: 2, payload: Data([1]))
+        XCTAssertNotEqual(a.id, b.id, "Two constructed rows must have distinct client-side UUIDs")
+    }
+
+    // MARK: - Persistence
+
+    func testRowSurvivesInsertAndFetch() throws {
+        let row = PendingOutcome(photoId: 7, payload: Data([0xCA, 0xFE]))
+        context.insert(row)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.photoId, 7)
+        XCTAssertEqual(fetched.first?.status, .pending)
+    }
+
+    // MARK: - Status transitions
+
+    func testStatusTransitionsThroughLifecycle() {
+        let row = PendingOutcome(photoId: 1, payload: Data([0]))
+        XCTAssertEqual(row.status, .pending)
+
+        row.status = .sending
+        XCTAssertEqual(row.status, .sending)
+
+        row.status = .delivered
+        XCTAssertEqual(row.status, .delivered)
+    }
+
+    func testStatusExpiredIsTerminal() {
+        let row = PendingOutcome(photoId: 1, payload: Data([0]))
+        row.status = .expired
+        XCTAssertEqual(row.status, .expired)
+    }
+
+    // MARK: - Backoff math (pure function on the manager)
+
+    func testBackoffStartsAt30Seconds() {
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 1), 30)
+    }
+
+    func testBackoffDoublesPerRetry() {
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 2), 60)
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 3), 120)
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 4), 240)
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 5), 480)
+    }
+
+    func testBackoffCapsAtOneHour() {
+        // 30 * 2^(n-1): crosses 3600s between retry 7 (1920) and retry 8 (3840).
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 7), 1920)
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 8), 3600,
+                       "Backoff must clamp at 1h regardless of retry count")
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 20), 3600,
+                       "20th retry must still clamp at 1h — no overflow")
+    }
+
+    func testBackoffZeroOrNegativeReturnsImmediate() {
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: 0), 0,
+                       "retryCount=0 means first attempt; no backoff required")
+        XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: -1), 0,
+                       "Negative retryCount defends against corrupt persistence")
+    }
+}

--- a/Bin Brain/Bin BrainTests/SuggestionReviewOutcomeQueueIntegrationTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewOutcomeQueueIntegrationTests.swift
@@ -1,0 +1,202 @@
+// SuggestionReviewOutcomeQueueIntegrationTests.swift
+// Bin BrainTests
+//
+// Swift2_018 — verifies that `SuggestionReviewViewModel.confirm()` routes
+// the outcomes POST through `OutcomeQueueManager.enqueue(...)` when the
+// view injects both the manager and a ModelContext. The pre-existing
+// `PhotoSuggestionOutcomesTests` still cover the legacy fire-and-forget
+// detached-Task path.
+
+import XCTest
+import SwiftData
+@testable import Bin_Brain
+
+@MainActor
+final class SuggestionReviewOutcomeQueueIntegrationTests: XCTestCase {
+
+    var container: ModelContainer!
+    var context: ModelContext!
+    var queue: OutcomeQueueManager!
+    var sut: SuggestionReviewViewModel!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let schema = Schema([PendingOutcome.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: config)
+        context = ModelContext(container)
+        queue = OutcomeQueueManager()
+        sut = SuggestionReviewViewModel()
+        sut.threeStateEnabled = false // exercise the legacy outcomes path
+        sut.outcomeQueueManager = queue
+        sut.outcomeQueueContext = context
+    }
+
+    override func tearDown() async throws {
+        OutcomeQueueMockURLProtocol.setHandler(nil)
+        sut = nil
+        queue = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockAPIClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        OutcomeQueueMockURLProtocol.setHandler(handler)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [OutcomeQueueMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func mockResponse(statusCode: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private func makeSuggestions() throws -> [SuggestionItem] {
+        let json = Data("""
+        [
+            {"item_id": null, "name": "Widget", "category": "Hardware", "confidence": 0.92, "bins": ["BIN-0001"]}
+        ]
+        """.utf8)
+        return try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+    }
+
+    private var upsertSuccessJSON: Data {
+        Data("""
+        {"version":"1","item_id":101,"fingerprint":"widget|hardware","name":"Widget","category":"Hardware"}
+        """.utf8)
+    }
+
+    private var associateSuccessJSON: Data {
+        Data("""
+        {"ok":true,"bin_id":"BIN-0001","item_id":101}
+        """.utf8)
+    }
+
+    private var confirmClassSuccessJSON: Data {
+        Data("""
+        {"version":"1","class_name":"Widget","added":true,"active_class_count":47,"reload_triggered":true}
+        """.utf8)
+    }
+
+    // MARK: - Success path persists a .delivered row
+
+    func testConfirmEnqueuesAndDeliversWhenQueueInjected() async throws {
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 42,
+                            visionModel: "vision-test",
+                            promptVersion: nil)
+
+        var outcomesHits = 0
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesHits += 1
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        // The enqueue runs in a detached Task; wait for it to settle.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(outcomesHits, 1,
+                       "Queue-injected VM must still emit exactly one /outcomes POST via enqueue")
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rows.count, 1,
+                       "Enqueue must persist exactly one PendingOutcome row")
+        XCTAssertEqual(rows.first?.status, .delivered,
+                       "2xx response must flip the persisted row to .delivered")
+        XCTAssertEqual(rows.first?.photoId, 42)
+    }
+
+    // MARK: - Failure path persists a .pending row for retry
+
+    func testConfirmPersistsPendingRowWhenOutcomes500() async throws {
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 42,
+                            visionModel: "vision-test",
+                            promptVersion: nil)
+
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                return (mockResponse(statusCode: 500, for: request), Data())
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.status, .pending,
+                       "5xx must leave the persisted row pending — NWPathMonitor / scenePhase sweep will retry")
+        XCTAssertEqual(row.retryCount, 1)
+        XCTAssertEqual(row.lastErrorCode, 500)
+    }
+
+    // MARK: - Guard: no queue injected → legacy path still works
+
+    func testConfirmWithoutQueueInjectionUsesLegacyPath() async throws {
+        // Drop the queue so the VM falls back to detached Task.
+        sut.outcomeQueueManager = nil
+        sut.outcomeQueueContext = nil
+
+        sut.loadSuggestions(try makeSuggestions(),
+                            photoId: 42,
+                            visionModel: "vision-test",
+                            promptVersion: nil)
+
+        var outcomesHits = 0
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/outcomes") {
+                outcomesHits += 1
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(outcomesHits, 1,
+                       "Legacy fire-and-forget path must still send the outcomes POST exactly once")
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertTrue(rows.isEmpty,
+                      "Legacy path must NOT touch the PendingOutcome store")
+    }
+}

--- a/Bin Brain/Bin BrainTests/SuggestionReviewOutcomeQueueIntegrationTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewOutcomeQueueIntegrationTests.swift
@@ -99,11 +99,11 @@ final class SuggestionReviewOutcomeQueueIntegrationTests: XCTestCase {
                             visionModel: "vision-test",
                             promptVersion: nil)
 
-        var outcomesHits = 0
+        let outcomesHit = expectation(description: "/outcomes POST reached the mock")
         let client = makeMockAPIClient { [self] request in
             let path = request.url?.path ?? ""
             if path.contains("/outcomes") {
-                outcomesHits += 1
+                outcomesHit.fulfill()
                 return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
             }
             if path.contains("/classes/confirm") {
@@ -116,17 +116,24 @@ final class SuggestionReviewOutcomeQueueIntegrationTests: XCTestCase {
         }
 
         await sut.confirm(binId: "BIN-0001", apiClient: client)
-        // The enqueue runs in a detached Task; wait for it to settle.
-        try await Task.sleep(nanoseconds: 100_000_000)
 
-        XCTAssertEqual(outcomesHits, 1,
-                       "Queue-injected VM must still emit exactly one /outcomes POST via enqueue")
-        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
-        XCTAssertEqual(rows.count, 1,
-                       "Enqueue must persist exactly one PendingOutcome row")
-        XCTAssertEqual(rows.first?.status, .delivered,
+        // F-2 durability guarantee: the row MUST be in the store by the
+        // time confirm() returns, with no async settling. An app-kill at
+        // this moment must not drop the outcome.
+        let rowsAtReturn = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rowsAtReturn.count, 1,
+                       "F-2: the PendingOutcome row must be durable the instant confirm() returns — no Task.sleep papering over races")
+        XCTAssertEqual(rowsAtReturn.first?.photoId, 42)
+
+        // Delivery itself is async; wait for the POST to land.
+        await fulfillment(of: [outcomesHit], timeout: 2.0)
+
+        // Give the delivery-branch `save` a chance to run, then re-fetch.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let rowsAfter = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rowsAfter.first?.status, .delivered,
                        "2xx response must flip the persisted row to .delivered")
-        XCTAssertEqual(rows.first?.photoId, 42)
     }
 
     // MARK: - Failure path persists a .pending row for retry
@@ -152,7 +159,15 @@ final class SuggestionReviewOutcomeQueueIntegrationTests: XCTestCase {
         }
 
         await sut.confirm(binId: "BIN-0001", apiClient: client)
-        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // F-2: row durable synchronously.
+        let rowsImmediate = try context.fetch(FetchDescriptor<PendingOutcome>())
+        XCTAssertEqual(rowsImmediate.count, 1,
+                       "F-2: row must be durable at confirm() return even on the failure path")
+
+        // Give the classify-and-save path a tick to land the 500 verdict.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
 
         let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
         let row = try XCTUnwrap(rows.first)

--- a/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewThreeStateTests.swift
@@ -124,6 +124,59 @@ final class SuggestionReviewThreeStateTests: XCTestCase {
                        "Unknown id must not mutate state — Karpathy: surgical changes")
     }
 
+    /// SEC-22-2 (LOW from PR #22 review): tapping the chip while the
+    /// upsert loop is in flight previously raced with the confirm-time
+    /// `included` filter. The view now disables the Button while
+    /// `isConfirming`; the VM-level guard is defence-in-depth so a direct
+    /// `cycleOutcome` call from code cannot corrupt state either.
+    ///
+    /// The mock handler parks the first `/items` request on a
+    /// `DispatchSemaphore` so the test can observe `isConfirming = true`,
+    /// call `cycleOutcome`, assert it was a no-op, then release the
+    /// semaphore to let confirm complete normally.
+    func testCycleOutcomeNoOpWhileConfirming() async throws {
+        sut.loadSuggestions(try makeSuggestions())
+        let id = sut.editableSuggestions[0].id
+        sut.cycleOutcome(id: id) // → .accepted so confirm has work to do
+
+        let hitItems = expectation(description: "/items request reached the mock")
+        let release = DispatchSemaphore(value: 0)
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path == "/items" {
+                hitItems.fulfill()
+                // Park the URL handler thread (sync context — `wait` is
+                // legal here) until the test releases it.
+                release.wait()
+                return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+            }
+            if path.contains("/outcomes") {
+                return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+            }
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        let confirmTask = Task { await sut.confirm(binId: "BIN-0001", apiClient: client) }
+        await fulfillment(of: [hitItems], timeout: 2.0)
+
+        XCTAssertTrue(sut.isConfirming, "precondition: confirm must be in flight")
+        let before = sut.editableSuggestions[0].outcomeState
+        sut.cycleOutcome(id: id)
+        XCTAssertEqual(sut.editableSuggestions[0].outcomeState, before,
+                       "Cycle must be a no-op while isConfirming — SEC-22-2")
+
+        // Let confirm finish.
+        release.signal()
+        await confirmTask.value
+        XCTAssertFalse(sut.isConfirming)
+    }
+
     // MARK: - Edit-flips-to-accepted
 
     func testEditingIgnoredRowAutoFlipsToAccepted() throws {


### PR DESCRIPTION
## Swift2_018 — Offline Outcomes Queue (2b-γ iOS)

Replaces the fire-and-forget `POST /photos/{id}/outcomes` with a SwiftData-backed
queue that retries on a capped exponential schedule, survives cold launches,
and surfaces state in Settings. Also bundles the **SEC-22-2** (LOW) finding
from the PR #22 review.

Plan: `../binbrain/thoughts/shared/plans/2026-04-19-swift2b-gamma-offline-outcomes.md`
Server contract: live (`client_retry_count` column + `X-Client-Retry-Count`
header deployed in server PR #33).

### What changed

**Model / service**
- `PendingOutcome` — `@Model` holding `id: UUID`, `photoId`, serialized `payload`,
  `queuedAt`, `retryCount`, `nextRetryAt`, `status` (`.pending / .sending /
  .delivered / .expired`), `lastErrorCode`.
- `OutcomeQueueManager` — `@Observable` manager with:
  - `enqueue(photoId:payload:context:apiClient:)` — writes the row, attempts
    immediate POST.
  - `drain(...)` — processes rows with `nextRetryAt <= now` and runs the 7-day
    TTL sweep.
  - `retryAll(...)` — forces every `.pending` row to attempt NOW.
  - `dismiss(_:context:)` — deletes an `.expired` row.
  - `startMonitoring(...)` — wires `NWPathMonitor(.satisfied)` +
    `UIApplication.willEnterForegroundNotification` to auto-drain.
  - Pure static `backoff(retryCount:)` — 30s, 1m, 2m, …, clamped at 1h.
- Response classification per plan: 2xx → `.delivered`; non-retryable 4xx
  (excluding 408/429) → `.expired`; 5xx/408/429/URLError → `.pending` with
  `retryCount += 1`; 20th consecutive failure forces `.expired`.

**APIClient**
- New `postPhotoSuggestionOutcomesRaw(photoId:body:clientRetryCount:)` returns
  the HTTP status directly so the queue can classify without decoding an empty
  response body. Sets `X-Client-Retry-Count` on every attempt.

**VM integration**
- `SuggestionReviewViewModel` gets optional `outcomeQueueManager` +
  `outcomeQueueContext` properties. When both are set (production), `confirm()`
  enqueues; when nil, the legacy detached-Task path still runs so the 30+
  existing `confirm(...)` tests keep passing without churn. `BinDetailView`
  and `BinsListView` inject both via `.onAppear`.

**SEC-22-2**
- Outcome chip Button `.disabled(viewModel.isConfirming)`.
- `cycleOutcome(id:)` is a no-op while `isConfirming` at the VM level too
  — defence-in-depth.

**App wiring**
- `Bin_BrainApp` registers `PendingOutcome.self` in the shared schema,
  owns a single `@State OutcomeQueueManager`, starts `startMonitoring` via
  `.task`, and drains on `scenePhase == .active`.

**Settings**
- New "Pending Outcomes" section with pending / delivered / expired counts,
  a "Retry all" button, and a NavigationLink to an `ExpiredOutcomesView`
  with `@Query`-driven list + swipe-to-dismiss.

### Tests (TDD, all URLProtocol-mocked)

- `PendingOutcomeTests` (9): CRUD, defaults, status transitions, backoff math
  (30s start, doubling, 1h cap, 20-retry cap, zero/negative defensive).
- `OutcomeQueueManagerTests` (13): enqueue 2xx → delivered + `X-Client-Retry-Count: 0`;
  5xx → pending + retry count increment + future `nextRetryAt` + `lastErrorCode`;
  422 → expired immediately; 408 / 429 → pending; `URLError` → pending;
  retryCount header echoes on subsequent attempts; 20-retry cap forces expired;
  7-day TTL sweep; `retryAll` ignores `nextRetryAt`; `drain` skips rows not yet
  due; `dismiss` deletes; observable counts match DB.
- `SuggestionReviewOutcomeQueueIntegrationTests` (3): queue-injected success
  persists `.delivered` + emits exactly one POST; queue-injected 5xx persists
  `.pending`; queue-absent falls back to legacy path without touching SwiftData.
- SEC-22-2 test in `SuggestionReviewThreeStateTests`: semaphore-parked mock
  holds `/items` so the test can observe `isConfirming == true` and assert
  `cycleOutcome` is a no-op mid-confirm.
- **494 tests pass on iPhone 17 simulator** (468 pre-Swift2_018 + 26 new).
  All network traffic intercepted by `OutcomeQueueMockURLProtocol` /
  `SuggestionReviewMockURLProtocol` — no real sockets, no prod DB risk.

### Out of scope (per prompt)

- Server-side changes — already deployed in server PR #33.
- Idempotency keys against the server — append-only telemetry tolerates
  rare duplicates.
- `Retry-After` header parsing — client-side backoff only.
- Removing the legacy fire-and-forget path — preserved to minimize churn
  on the 30+ existing outcomes/confirm tests. Can be pruned in a dedicated
  follow-up once those suites are migrated.

### How to verify

1. Toggle airplane mode on; capture + confirm a photo → Settings → Pending
   Outcomes shows `Pending: 1`.
2. Toggle airplane mode off → NWPathMonitor fires a drain; Pending drops to
   0, Delivered climbs to 1.
3. Force an outcomes 422 (e.g. malformed payload) via server-side fault
   injection → row lands in "Expired"; swipe to dismiss.

🤖 Generated for Swift2_018.
