### PR TITLE
feat(sessions): SessionManager + /sessions integration (Swift2_019)

### DIFF
--- a/Bin Brain/Bin Brain/Bin_BrainApp.swift
+++ b/Bin Brain/Bin Brain/Bin_BrainApp.swift
@@ -20,6 +20,7 @@ struct Bin_BrainApp: App {
     @State private var apiClient = APIClient()
     @State private var uploadQueueManager = UploadQueueManager()
     @State private var outcomeQueueManager = OutcomeQueueManager()
+    @State private var sessionManager = SessionManager()
     @State private var serverMonitor = ServerMonitor()
 
     // MARK: - Initializer
@@ -75,6 +76,7 @@ struct Bin_BrainApp: App {
                 .environment(\.apiClient, apiClient)
                 .environment(\.uploadQueueManager, uploadQueueManager)
                 .environment(\.outcomeQueueManager, outcomeQueueManager)
+                .environment(\.sessionManager, sessionManager)
                 .environment(\.serverMonitor, serverMonitor)
         }
         .modelContainer(sharedModelContainer)

--- a/Bin Brain/Bin Brain/EnvironmentKeys.swift
+++ b/Bin Brain/Bin Brain/EnvironmentKeys.swift
@@ -35,6 +35,23 @@ extension EnvironmentValues {
     }
 }
 
+// MARK: - SessionManager
+
+struct SessionManagerKey: EnvironmentKey {
+    @MainActor
+    static let defaultValue = SessionManager()
+}
+
+extension EnvironmentValues {
+    /// The shared `SessionManager` for the cataloging-session lifecycle
+    /// (Swift2_019). Every `/ingest` must carry the session_id this
+    /// manager tracks.
+    var sessionManager: SessionManager {
+        get { self[SessionManagerKey.self] }
+        set { self[SessionManagerKey.self] = newValue }
+    }
+}
+
 // MARK: - OutcomeQueueManager
 
 struct OutcomeQueueManagerKey: EnvironmentKey {

--- a/Bin Brain/Bin Brain/Models/APIModels.swift
+++ b/Bin Brain/Bin Brain/Models/APIModels.swift
@@ -209,6 +209,28 @@ struct GetBinResponse: Decodable {
     }
 }
 
+// MARK: - Sessions
+
+/// A server-minted cataloging session. `Swift2_019` — the client requests one
+/// from `POST /sessions`, plumbs `session_id` through every photo ingest, and
+/// closes it via `DELETE /sessions/{session_id}` when the user is done or the
+/// 30-min idle timer fires.
+struct Session: Codable, Identifiable, Equatable, Sendable {
+    let id: UUID
+    let startedAt: Date
+    let endedAt: Date?
+    let label: String?
+    let photoCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id = "session_id"
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+        case label
+        case photoCount = "photo_count"
+    }
+}
+
 // MARK: - Ingest
 
 /// The response returned by `POST /ingest`.

--- a/Bin Brain/Bin Brain/Services/APIClient.swift
+++ b/Bin Brain/Bin Brain/Services/APIClient.swift
@@ -216,10 +216,21 @@ final class APIClient {
     ///   - deviceMetadata: Optional JSON string of on-device processing metadata
     ///     (quality scores, OCR, barcodes, classifications). Sent as a
     ///     `device_metadata` text field in the multipart body when non-nil.
-    func ingest(jpegData: Data, binId: String, deviceMetadata: String? = nil) async throws -> IngestResponse {
+    ///   - sessionId: Optional server-minted session UUID (`Swift2_019`).
+    ///     Sent as a `session_id` multipart field. Server PR #35 rejects
+    ///     any non-UUID value with 400 `invalid_session`.
+    func ingest(
+        jpegData: Data,
+        binId: String,
+        deviceMetadata: String? = nil,
+        sessionId: UUID? = nil
+    ) async throws -> IngestResponse {
         var fields = ["bin_id": binId]
         if let deviceMetadata {
             fields["device_metadata"] = deviceMetadata
+        }
+        if let sessionId {
+            fields["session_id"] = sessionId.uuidString.lowercased()
         }
         let (body, boundary) = multipartBody(
             fields: fields,
@@ -233,6 +244,79 @@ final class APIClient {
             body: body,
             contentType: "multipart/form-data; boundary=\(boundary)",
             timeout: 30
+        )
+    }
+
+    // MARK: - Sessions (Swift2_019)
+
+    /// Creates a new server-minted cataloging session. Response row contains
+    /// the `session_id` that subsequent `/ingest` calls must carry.
+    ///
+    /// - Parameter label: Optional human-readable hint, e.g.
+    ///   `"Garage bins 2026-04-19"`. Max 120 chars server-side.
+    /// - Returns: The freshly-opened `Session`.
+    func createSession(label: String? = nil) async throws -> Session {
+        let body: Data
+        if let label {
+            body = try JSONSerialization.data(withJSONObject: ["label": label])
+        } else {
+            body = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        }
+        return try await request(
+            path: "/sessions",
+            method: "POST",
+            body: body,
+            contentType: "application/json",
+            timeout: 10
+        )
+    }
+
+    /// Closes the given session on the server. 404 / 410 responses are
+    /// treated as idempotent success because both mean "already gone" —
+    /// the server-side row is in a terminal state either way.
+    ///
+    /// - Parameter id: The session UUID to close.
+    /// - Returns: The closed session row (or `nil` if 404/410).
+    /// - Throws: `URLError` on transport failure so the caller can decide
+    ///   whether to retry. All other HTTP-layer errors bubble up via
+    ///   `APIClientError.unexpectedStatusCode`.
+    @discardableResult
+    func endSession(id: UUID) async throws -> Session? {
+        // Bypass the generic request<T> path so we can treat 404/410 as
+        // success without relying on throw/catch control flow.
+        guard hasAPIKey else { throw APIClientError.missingAPIKey }
+        let path = "/sessions/\(id.uuidString.lowercased())"
+        let urlString = baseURL + path
+        guard let url = URL(string: urlString) else {
+            throw APIClientError.invalidURL(urlString)
+        }
+        var urlRequest = URLRequest(url: url, timeoutInterval: 10)
+        urlRequest.httpMethod = "DELETE"
+        if let apiKey, shouldAttachKey(requiresAuth: true, probe: false) {
+            urlRequest.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
+
+        let (data, response) = try await session.data(for: urlRequest)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIClientError.unexpectedStatusCode(-1)
+        }
+        if (200...299).contains(http.statusCode) {
+            return try? JSONDecoder.binBrain.decode(Session.self, from: data)
+        }
+        if http.statusCode == 404 || http.statusCode == 410 {
+            return nil
+        }
+        throw APIClientError.unexpectedStatusCode(http.statusCode)
+    }
+
+    /// Fetches a single session by id. 404 if not owned or not found.
+    func getSession(id: UUID) async throws -> Session {
+        try await request(
+            path: "/sessions/\(id.uuidString.lowercased())",
+            method: "GET",
+            body: nil,
+            contentType: nil,
+            timeout: 10
         )
     }
 

--- a/Bin Brain/Bin Brain/Services/SessionManager.swift
+++ b/Bin Brain/Bin Brain/Services/SessionManager.swift
@@ -1,0 +1,130 @@
+// SessionManager.swift
+// Bin Brain
+//
+// Swift2_019 — owns the server-minted cataloging-session lifecycle.
+// Server PR #35 made `session_id` validation strict on `/ingest`; this
+// class is the single source of truth for the current session UUID,
+// transparently opens one on first ingest, and auto-closes after 30 min
+// of inactivity.
+//
+// Deliberately lean: no offline-queue integration yet. End-session
+// failures log and clear state locally; the server's open-session
+// sweep catches anything we don't explicitly close. Swift2_018b can
+// plug a SessionCloseQueue in later if telemetry shows abandoned rows.
+
+import Foundation
+import OSLog
+import Observation
+
+private let logger = Logger(subsystem: "com.binbrain.app", category: "SessionManager")
+
+// MARK: - SessionManager
+
+/// Main-actor singleton that tracks the active `Session`. Views and
+/// view-models read `current` to plumb `session_id` into `/ingest`; the
+/// idle timer closes the session after 30 min of no `noteActivity` calls.
+@MainActor
+@Observable
+final class SessionManager {
+
+    // MARK: - Observable state
+
+    /// Server-returned session that outbound ingests should join.
+    /// Nil between sessions.
+    private(set) var current: Session?
+
+    // MARK: - Configuration
+
+    /// Seconds of inactivity before the session auto-closes. Production
+    /// default is 30 min; tests pass a tiny value to exercise the fire.
+    let idleTimeout: TimeInterval
+
+    // MARK: - Private
+
+    /// Cancellable auto-close task. Any call to `noteActivity` cancels
+    /// the existing task and schedules a fresh one.
+    private var idleTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(idleTimeout: TimeInterval = 30 * 60) {
+        self.idleTimeout = idleTimeout
+    }
+
+    // MARK: - Lifecycle
+
+    /// Creates a new session on the server and stores it as `current`.
+    /// Arms the idle timer so inactive clients don't leak open sessions.
+    @discardableResult
+    func beginSession(label: String? = nil, apiClient: APIClient) async throws -> Session {
+        let session = try await apiClient.createSession(label: label)
+        current = session
+        scheduleIdleAutoClose(apiClient: apiClient)
+        return session
+    }
+
+    /// Fire-and-forget close. Returns when the network call completes
+    /// (or fails). 404 / 410 / transport errors all clear `current`
+    /// because the server side is either gone or will be cleaned up by
+    /// the idle-sweep — forcing the user to stare at a spinner on a
+    /// best-effort close is worse than the rare orphaned row.
+    func endSession(apiClient: APIClient) async {
+        cancelIdleTimer()
+        guard let session = current else { return }
+        do {
+            _ = try await apiClient.endSession(id: session.id)
+        } catch {
+            logger.error("[SESSION] close failed: \(error.localizedDescription, privacy: .private) — clearing local state anyway")
+        }
+        current = nil
+    }
+
+    /// Reset the idle timer. Call from photo capture, confirm tap, any
+    /// user-initiated activity that means "still actively cataloging".
+    func noteActivity(apiClient: APIClient) {
+        guard current != nil else { return }
+        scheduleIdleAutoClose(apiClient: apiClient)
+    }
+
+    /// Clears `current` without calling the server. Intended for the
+    /// `invalid_session` 400 path — the server already told us the row
+    /// is gone, so any DELETE would just 404.
+    func invalidateCurrentSession() {
+        cancelIdleTimer()
+        current = nil
+    }
+
+    // MARK: - Convenience
+
+    /// Returns the active session id, opening a fresh session if there
+    /// isn't one yet. Use at every ingest call site so the "first photo
+    /// after app launch" path doesn't require the user to tap anything.
+    func activeSessionId(apiClient: APIClient) async throws -> UUID {
+        if let existing = current {
+            return existing.id
+        }
+        let session = try await beginSession(apiClient: apiClient)
+        return session.id
+    }
+
+    // MARK: - Idle timer
+
+    /// Cancels any pending auto-close. Exposed internal so tests can
+    /// tear the timer down in `tearDown` without leaking Tasks into the
+    /// next test.
+    func cancelIdleTimer() {
+        idleTask?.cancel()
+        idleTask = nil
+    }
+
+    private func scheduleIdleAutoClose(apiClient: APIClient) {
+        idleTask?.cancel()
+        let timeout = idleTimeout
+        idleTask = Task { [weak self] in
+            let nanos = UInt64(max(0, timeout) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanos)
+            guard !Task.isCancelled else { return }
+            await self?.endSession(apiClient: apiClient)
+        }
+    }
+}

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -125,8 +125,13 @@ final class AnalysisViewModel {
     ///   - jpegData: Raw JPEG bytes to upload (compressed before sending).
     ///   - binId: The bin identifier to associate the photo with.
     ///   - apiClient: The `APIClient` instance to use for network calls.
+    ///   - sessionId: Server-minted session UUID (`Swift2_019`). When
+    ///     present, forwarded to `/ingest` as the `session_id` multipart
+    ///     field. Callers typically obtain this by awaiting
+    ///     `SessionManager.activeSessionId(apiClient:)` so the first
+    ///     photo after launch opens a session transparently.
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
-    func run(jpegData: Data, binId: String, apiClient: APIClient, context: ModelContext? = nil) async {
+    func run(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, context: ModelContext? = nil) async {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         preliminaryClassifications = []
@@ -220,7 +225,8 @@ final class AnalysisViewModel {
             ingestResponse = try await apiClient.ingest(
                 jpegData: uploadData,
                 binId: binId,
-                deviceMetadata: metadataString
+                deviceMetadata: metadataString,
+                sessionId: sessionId
             )
         } catch {
             phase = .failed(error.localizedDescription)
@@ -294,7 +300,7 @@ final class AnalysisViewModel {
     ///   - binId: The bin identifier to associate the photo with.
     ///   - apiClient: The `APIClient` instance to use for network calls.
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
-    func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, context: ModelContext? = nil) async {
+    func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, context: ModelContext? = nil) async {
         // Finding #19 — same BG task protection as run() so the #18 180 s
         // /suggest window doesn't get OS-killed if the user backgrounds
         // after tapping "Upload Anyway".
@@ -340,7 +346,8 @@ final class AnalysisViewModel {
             ingestResponse = try await apiClient.ingest(
                 jpegData: uploadData,
                 binId: binId,
-                deviceMetadata: metadataString
+                deviceMetadata: metadataString,
+                sessionId: sessionId
             )
         } catch {
             phase = .failed(error.localizedDescription)

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -39,6 +39,7 @@ struct BinDetailView: View {
     @Environment(\.apiClient) private var apiClient
     @Environment(\.modelContext) private var modelContext
     @Environment(\.outcomeQueueManager) private var outcomeQueueManager
+    @Environment(\.sessionManager) private var sessionManager
     @State private var showAddItem = false
     @State private var showCamera = false
     @State private var sortOrder: SortOrder = .name
@@ -232,10 +233,17 @@ struct BinDetailView: View {
                         reviewViewModel.binId = binId
                         catalogingPath.append(.analysis)
                         Task {
+                            // Swift2_019 — transparently open a session on
+                            // the first photo so the natural "open app, tap
+                            // shutter" flow still works. SessionManager
+                            // caches the id for subsequent captures and
+                            // auto-closes after 30 min of inactivity.
+                            let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                             await analysisViewModel.run(
                                 jpegData: rawData,
                                 binId: binId,
                                 apiClient: apiClient,
+                                sessionId: sessionId,
                                 context: modelContext
                             )
                         }
@@ -314,10 +322,12 @@ struct BinDetailView: View {
                 Task {
                     guard let data = capturedPhotoData else { return }
                     navigatedOnPreliminary = false
+                    let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                     await analysisViewModel.overrideQualityGate(
                         jpegData: data,
                         binId: binId,
                         apiClient: apiClient,
+                        sessionId: sessionId,
                         context: modelContext
                     )
                 }

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -47,6 +47,7 @@ struct BinsListView: View {
     @Environment(\.apiClient) private var apiClient
     @Environment(\.modelContext) private var modelContext
     @Environment(\.outcomeQueueManager) private var outcomeQueueManager
+    @Environment(\.sessionManager) private var sessionManager
     @Environment(\.embeddedInSplitView) private var embeddedInSplitView
 
     // Cataloging flow
@@ -143,10 +144,14 @@ struct BinsListView: View {
                         // Launch analysis in an unstructured Task so SwiftUI
                         // re-renders cannot cancel the in-flight network call.
                         Task {
+                            // Swift2_019 — transparently open a server
+                            // session so /ingest passes the new validator.
+                            let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                             await analysisViewModel.run(
                                 jpegData: rawData,
                                 binId: binId,
                                 apiClient: apiClient,
+                                sessionId: sessionId,
                                 context: modelContext
                             )
                         }
@@ -250,10 +255,12 @@ struct BinsListView: View {
                     guard let data = capturedPhotoData,
                           let binId = capturedBinId else { return }
                     navigatedOnPreliminary = false
+                    let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                     await analysisViewModel.overrideQualityGate(
                         jpegData: data,
                         binId: binId,
                         apiClient: apiClient,
+                        sessionId: sessionId,
                         context: modelContext
                     )
                 }

--- a/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
+++ b/Bin Brain/Bin Brain/Views/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @Environment(\.apiClient) private var apiClient
     @Environment(\.uploadQueueManager) private var uploadQueueManager
     @Environment(\.outcomeQueueManager) private var outcomeQueueManager
+    @Environment(\.sessionManager) private var sessionManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.embeddedInSplitView) private var embeddedInSplitView
 
@@ -55,6 +56,7 @@ struct SettingsView: View {
             imageSizeSection
             searchSection
             catalogingSection
+            sessionSection
             uploadQueueSection
             outcomeQueueSection
         }
@@ -384,6 +386,35 @@ struct SettingsView: View {
 
             Button("Clear Queue", role: .destructive) {
                 uploadQueueManager.clearQueue(context: modelContext)
+            }
+        }
+    }
+
+    // MARK: - Session (Swift2_019)
+
+    @ViewBuilder
+    private var sessionSection: some View {
+        Section("Cataloging Session") {
+            if let session = sessionManager.current {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(session.label ?? "Active session")
+                        .font(.headline)
+                    Text("Started \(session.startedAt.formatted(date: .abbreviated, time: .shortened))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Photos: \(session.photoCount)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Button("End session now", role: .destructive) {
+                    Task { await sessionManager.endSession(apiClient: apiClient) }
+                }
+            } else {
+                Text("No active session")
+                    .foregroundStyle(.secondary)
+                Text("Opens automatically on your next photo.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/Bin Brain/Bin BrainTests/SessionManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/SessionManagerTests.swift
@@ -1,0 +1,285 @@
+// SessionManagerTests.swift
+// Bin BrainTests
+//
+// Swift2_019 — SessionManager drives the POST /sessions lifecycle,
+// 30-min idle auto-close, and ingest auto-begin. Every test routes
+// through URLProtocol mocks; no real sockets, no prod DB risk.
+
+import XCTest
+@testable import Bin_Brain
+
+// MARK: - URLProtocol interceptor (distinct name per suite)
+
+final class SessionMockURLProtocol: URLProtocol {
+    private static let handlerLock = NSLock()
+    nonisolated(unsafe) private static var _handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func setHandler(_ handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        _handler = handler
+    }
+
+    static func currentHandler() -> ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        return _handler
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.currentHandler() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class SessionManagerTests: XCTestCase {
+
+    var sut: SessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SessionManager(idleTimeout: 30 * 60)
+    }
+
+    override func tearDown() async throws {
+        SessionMockURLProtocol.setHandler(nil)
+        sut.cancelIdleTimer()
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        SessionMockURLProtocol.setHandler(handler)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SessionMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func response(_ statusCode: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private let fixedSessionId = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+    private var sessionJSON: Data {
+        Data("""
+        {
+            "session_id": "11111111-2222-3333-4444-555555555555",
+            "started_at": "2026-04-19T12:00:00Z",
+            "ended_at": null,
+            "label": null,
+            "photo_count": 0
+        }
+        """.utf8)
+    }
+
+    // MARK: - beginSession
+
+    func testBeginSessionPostsToSessionsAndStoresCurrent() async throws {
+        var capturedMethod: String?
+        var capturedPath: String?
+        let client = makeClient { [self] request in
+            capturedMethod = request.httpMethod
+            capturedPath = request.url?.path
+            return (response(201, for: request), sessionJSON)
+        }
+
+        let session = try await sut.beginSession(apiClient: client)
+
+        XCTAssertEqual(capturedMethod, "POST")
+        XCTAssertEqual(capturedPath, "/sessions")
+        XCTAssertEqual(session.id, fixedSessionId)
+        XCTAssertEqual(sut.current?.id, fixedSessionId,
+                       "beginSession must store the server-minted session on self.current")
+    }
+
+    // MARK: - endSession happy path
+
+    func testEndSessionDeletesAndClearsCurrent() async throws {
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON)
+            }
+            // DELETE /sessions/{id}
+            return (response(200, for: request), sessionJSON)
+        }
+
+        _ = try await sut.beginSession(apiClient: client)
+        XCTAssertNotNil(sut.current, "precondition")
+
+        await sut.endSession(apiClient: client)
+        XCTAssertNil(sut.current, "endSession must clear current on 2xx")
+    }
+
+    // MARK: - 404 / 410 are idempotent success
+
+    func testEndSession404TreatedAsSuccess() async throws {
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(404, for: request), Data())
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        await sut.endSession(apiClient: client)
+
+        XCTAssertNil(sut.current,
+                     "404 on DELETE means the session is already gone server-side — clear locally")
+    }
+
+    func testEndSession410TreatedAsSuccess() async throws {
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(410, for: request), Data())
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        await sut.endSession(apiClient: client)
+
+        XCTAssertNil(sut.current,
+                     "410 Gone on DELETE is idempotent success — client treats as already closed")
+    }
+
+    // MARK: - Network failure on end is best-effort
+
+    func testEndSessionNetworkFailureStillClearsCurrent() async throws {
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST" {
+                return (response(201, for: request), sessionJSON)
+            }
+            throw URLError(.notConnectedToInternet)
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        await sut.endSession(apiClient: client)
+
+        XCTAssertNil(sut.current,
+                     "Network failure on close must not block UX — clear locally so the user can start fresh; server idle-cleanup covers the row")
+    }
+
+    // MARK: - Idle timer
+
+    func testIdleTimerAutoClosesSessionAfterTimeout() async throws {
+        sut = SessionManager(idleTimeout: 0.15) // short for test
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST" {
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(200, for: request), sessionJSON)
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        sut.noteActivity(apiClient: client) // arms the timer
+        // Wait longer than idleTimeout so the Task fires.
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertNil(sut.current,
+                     "30-min idle timer — simulated at 0.15s here — must auto-end the session")
+    }
+
+    func testNoteActivityResetsIdleTimer() async throws {
+        sut = SessionManager(idleTimeout: 0.25)
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST" {
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(200, for: request), sessionJSON)
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        sut.noteActivity(apiClient: client)
+        try await Task.sleep(nanoseconds: 120_000_000) // 0.12s — not yet idle
+        sut.noteActivity(apiClient: client) // reset
+        try await Task.sleep(nanoseconds: 120_000_000) // 0.24s total, but reset at 0.12 — still within window
+
+        XCTAssertNotNil(sut.current,
+                        "noteActivity must reset the idle timer so active users aren't auto-logged-out")
+    }
+
+    // MARK: - invalidateCurrentSession
+
+    func testInvalidateCurrentSessionClearsWithoutNetworkCall() async throws {
+        let client = makeClient { [self] request in
+            (response(201, for: request), sessionJSON)
+        }
+        _ = try await sut.beginSession(apiClient: client)
+
+        // Simulate the server returning 400 invalid_session on a later ingest:
+        // callers tell the SessionManager to drop the current session so the
+        // next ingest auto-begins a fresh one.
+        sut.invalidateCurrentSession()
+
+        XCTAssertNil(sut.current,
+                     "invalidateCurrentSession must clear current with no network call")
+    }
+
+    // MARK: - activeSessionId auto-begins
+
+    func testActiveSessionIdAutoBeginsWhenCurrentIsNil() async throws {
+        var postCount = 0
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(200, for: request), sessionJSON)
+        }
+
+        let id = try await sut.activeSessionId(apiClient: client)
+
+        XCTAssertEqual(id, fixedSessionId)
+        XCTAssertEqual(postCount, 1, "Nil current must trigger POST /sessions")
+        XCTAssertNotNil(sut.current, "current must be populated after auto-begin")
+    }
+
+    func testActiveSessionIdReturnsExistingWithoutBeginning() async throws {
+        var postCount = 0
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(200, for: request), sessionJSON)
+        }
+        _ = try await sut.beginSession(apiClient: client)
+        XCTAssertEqual(postCount, 1, "precondition: one begin")
+
+        let id = try await sut.activeSessionId(apiClient: client)
+
+        XCTAssertEqual(id, fixedSessionId)
+        XCTAssertEqual(postCount, 1,
+                       "Existing current must not trigger another POST /sessions")
+    }
+}


### PR DESCRIPTION
## Swift2_019 — SessionManager + /sessions Integration (URGENT)

Closes the iOS-broken window opened by server PR #35 (`dd40bb3`), which made
`/ingest` reject any non-UUID `session_id` with 400 `invalid_session`.

Plan: `../binbrain/thoughts/shared/plans/2026-04-19-session-id-explicit-boundary.md`
Server contract: live since the PR #35 deploy.

### What changed

**Model + APIClient**
- `Session` Codable/Identifiable/Equatable model — `id` / `startedAt` /
  `endedAt` / `label` / `photoCount`, mapped to the server's snake_case JSON.
- `APIClient.createSession(label:)` — POST `/sessions`, returns the minted
  row.
- `APIClient.endSession(id:)` — DELETE `/sessions/{id}`; 404 and 410 are
  idempotent success (server row already gone). Transport failures throw
  `URLError` so the caller can decide; non-2xx/non-404/410 bubble up via
  `APIClientError.unexpectedStatusCode`.
- `APIClient.getSession(id:)` — GET, wired for the Settings read path.
- `APIClient.ingest(...)` gains optional `sessionId: UUID?`. When set,
  lower-cases the UUID and sends it as a `session_id` multipart field.

**SessionManager service**
- `@MainActor @Observable final class` owning `current: Session?`.
- `beginSession(label:apiClient:)` — posts a new session, arms the idle timer.
- `endSession(apiClient:)` — best-effort close: any transport / 404 / 410 /
  server failure clears `current` locally so the user isn't stuck staring at
  a spinner. Server's open-session sweep catches orphans.
- `activeSessionId(apiClient:)` — returns the current id, or opens a new
  session on demand. Every ingest call site awaits this so "open app, tap
  shutter" still works on the first photo after launch.
- `noteActivity(apiClient:)` — cancels + reschedules the 30-min idle
  auto-close (implemented via `Task.sleep` + cancellation, no `NSTimer`).
- `invalidateCurrentSession()` — synchronous local clear for the server
  `invalid_session` 400 recovery path.

**Plumbing**
- `AnalysisViewModel.run` / `.overrideQualityGate` gain `sessionId: UUID?`,
  forwarded straight to `apiClient.ingest(...)`.
- `BinsListView` + `BinDetailView` resolve `sessionManager.activeSessionId`
  before kicking the analysis flow; same for `onOverride`.
- `Bin_BrainApp` owns one `@State SessionManager`, plumbed via a new
  `sessionManager` environment key.

**Settings**
- New "Cataloging Session" section. Active → shows label, start time,
  photo count, and an "End session now" destructive button. Inactive →
  "No active session · Opens automatically on your next photo".

### Tests (TDD, URLProtocol-mocked throughout)

`SessionManagerTests` — 10 cases:
- `beginSession` posts `/sessions`, stores current.
- `endSession` DELETE + clears current.
- `endSession` 404 → clears (idempotent).
- `endSession` 410 → clears (idempotent).
- Network failure on `endSession` → still clears (best-effort UX).
- 30-min idle timer (simulated at 0.15s) fires auto-close.
- `noteActivity` resets the idle timer (doesn't double-up).
- `invalidateCurrentSession` clears without network call.
- `activeSessionId` auto-begins when `current == nil`.
- `activeSessionId` reuses existing when `current != nil`.

**Full suite: 507 pass on iPhone 17 simulator** (was 497 after PR #23 merge).
Every mock uses `SessionMockURLProtocol` — no real sockets, no risk of
polluting the prod DB.

### Out of scope (per prompt)

- `Bin Brain Test` separate scheme + dedicated test base URL — track as
  `Swift_TestIso` backlog.
- Past-sessions browsing UI — defer.
- SessionCloseQueue (offline end-retry queue). Server's idle-cleanup
  handles orphans; Swift2_018b can layer a queue in later if telemetry
  shows abandonment.
- `POST /sessions` 429 handling (>20 open sessions) — server hasn't
  surfaced this in the wild; generic `APIClientError.unexpectedStatusCode`
  path covers it for now.

### Why this is urgent

Server PR #35 is in prod. Until this lands, `/ingest` 400s on every photo
upload. Stephen coordinated the brief outage.

🤖 Generated for Swift2_019.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session management system for photo cataloging with automatic inactivity timeout (closes idle sessions after 30 minutes)
  * Create labeled sessions to organize photo uploads
  * View active session details (label, start time, photo count) and manually end sessions in Settings
  * Photos automatically associated with the active session during upload

<!-- end of auto-generated comment: release notes by coderabbit.ai -->