### PR TITLE
fix(sessions): wire invalid_session recovery + serialize auto-begin (Swift2_019b)

### DIFF
--- a/Bin Brain/Bin Brain/Services/SessionManager.swift
+++ b/Bin Brain/Bin Brain/Services/SessionManager.swift
@@ -97,7 +97,15 @@ final class SessionManager {
     /// Clears `current` without calling the server. Intended for the
     /// `invalid_session` 400 path — the server already told us the row
     /// is gone, so any DELETE would just 404.
-    func invalidateCurrentSession() {
+    ///
+    /// `ifCurrentIs` guards against a stale-id recovery clobbering a
+    /// newer legitimate session (Swift2_019b G-1 / PR #25 QA review):
+    /// if the caller passes the id it *thinks* it's invalidating and
+    /// `current` has since moved on, the clear is a no-op. The
+    /// zero-argument call (optional defaults to `nil`) preserves the
+    /// prior unconditional-clear behaviour for sign-out flows.
+    func invalidateCurrentSession(ifCurrentIs staleId: UUID? = nil) {
+        if let staleId, current?.id != staleId { return }
         cancelIdleTimer()
         current = nil
     }

--- a/Bin Brain/Bin Brain/Services/SessionManager.swift
+++ b/Bin Brain/Bin Brain/Services/SessionManager.swift
@@ -45,6 +45,14 @@ final class SessionManager {
     /// the existing task and schedules a fresh one.
     private var idleTask: Task<Void, Never>?
 
+    /// In-flight `beginSession` memoization (Swift2_019b / SEC-24-2).
+    /// Concurrent `activeSessionId` callers see this value and await the
+    /// same Task instead of each firing their own `POST /sessions`.
+    /// Main-actor isolation guarantees the `beginTask = task` assignment
+    /// and the first-reader `if let beginTask` check serialize correctly
+    /// — no lock needed.
+    private var beginTask: Task<Session, Error>?
+
     // MARK: - Init
 
     init(idleTimeout: TimeInterval = 30 * 60) {
@@ -99,12 +107,26 @@ final class SessionManager {
     /// Returns the active session id, opening a fresh session if there
     /// isn't one yet. Use at every ingest call site so the "first photo
     /// after app launch" path doesn't require the user to tap anything.
+    ///
+    /// Swift2_019b / SEC-24-2 — concurrent callers hitting this while
+    /// `current == nil` previously raced: both passed the gate, both
+    /// awaited `beginSession`, both POSTed `/sessions` — orphaning
+    /// sessions against the server's 20-open cap. Now each concurrent
+    /// caller awaits the same memoized `beginTask`.
     func activeSessionId(apiClient: APIClient) async throws -> UUID {
         if let existing = current {
             return existing.id
         }
-        let session = try await beginSession(apiClient: apiClient)
-        return session.id
+        if let inflight = beginTask {
+            return try await inflight.value.id
+        }
+        let task = Task<Session, Error> { [weak self] in
+            guard let self else { throw CancellationError() }
+            return try await self.beginSession(apiClient: apiClient)
+        }
+        beginTask = task
+        defer { beginTask = nil }
+        return try await task.value.id
     }
 
     // MARK: - Idle timer

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -130,8 +130,15 @@ final class AnalysisViewModel {
     ///     field. Callers typically obtain this by awaiting
     ///     `SessionManager.activeSessionId(apiClient:)` so the first
     ///     photo after launch opens a session transparently.
+    ///   - sessionManager: Optional `SessionManager` reference
+    ///     (`Swift2_019b` / SEC-24-1). When present, an `/ingest` failure
+    ///     that decodes as `APIError { code == "invalid_session" }`
+    ///     invalidates the cached session, auto-begins a fresh one via
+    ///     `activeSessionId`, and retries `/ingest` once. Without this
+    ///     wiring the client loops on 400s whenever the server rotates
+    ///     or sweeps the cached session_id.
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
-    func run(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, context: ModelContext? = nil) async {
+    func run(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, sessionManager: SessionManager? = nil, context: ModelContext? = nil) async {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         preliminaryClassifications = []
@@ -222,11 +229,13 @@ final class AnalysisViewModel {
 
         let ingestResponse: IngestResponse
         do {
-            ingestResponse = try await apiClient.ingest(
+            ingestResponse = try await Self.ingestWithSessionRecovery(
                 jpegData: uploadData,
                 binId: binId,
                 deviceMetadata: metadataString,
-                sessionId: sessionId
+                sessionId: sessionId,
+                sessionManager: sessionManager,
+                apiClient: apiClient
             )
         } catch {
             phase = .failed(error.localizedDescription)
@@ -300,7 +309,7 @@ final class AnalysisViewModel {
     ///   - binId: The bin identifier to associate the photo with.
     ///   - apiClient: The `APIClient` instance to use for network calls.
     ///   - context: An optional `ModelContext` for persisting a `PendingAnalysis` on background task expiry.
-    func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, context: ModelContext? = nil) async {
+    func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, sessionManager: SessionManager? = nil, context: ModelContext? = nil) async {
         // Finding #19 — same BG task protection as run() so the #18 180 s
         // /suggest window doesn't get OS-killed if the user backgrounds
         // after tapping "Upload Anyway".
@@ -343,11 +352,13 @@ final class AnalysisViewModel {
 
         let ingestResponse: IngestResponse
         do {
-            ingestResponse = try await apiClient.ingest(
+            ingestResponse = try await Self.ingestWithSessionRecovery(
                 jpegData: uploadData,
                 binId: binId,
                 deviceMetadata: metadataString,
-                sessionId: sessionId
+                sessionId: sessionId,
+                sessionManager: sessionManager,
+                apiClient: apiClient
             )
         } catch {
             phase = .failed(error.localizedDescription)
@@ -427,5 +438,47 @@ final class AnalysisViewModel {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         lastUploadedPhotoData = nil
+    }
+
+    // MARK: - Session recovery (Swift2_019b / SEC-24-1)
+
+    /// Posts `/ingest` and, on server `invalid_session`, invalidates the
+    /// cached `SessionManager` session, auto-begins a fresh one, and
+    /// retries exactly once. If the retry fails (any error), that error
+    /// propagates — the caller surfaces it normally and we never loop.
+    ///
+    /// Exposed as `static` so the logic is pure and testable from both
+    /// `run(...)` and `overrideQualityGate(...)` without duplicating the
+    /// try/catch ladder.
+    static func ingestWithSessionRecovery(
+        jpegData: Data,
+        binId: String,
+        deviceMetadata: String?,
+        sessionId: UUID?,
+        sessionManager: SessionManager?,
+        apiClient: APIClient
+    ) async throws -> IngestResponse {
+        do {
+            return try await apiClient.ingest(
+                jpegData: jpegData,
+                binId: binId,
+                deviceMetadata: deviceMetadata,
+                sessionId: sessionId
+            )
+        } catch let apiError as APIError where apiError.error.code == "invalid_session" {
+            // Server invalidated our cached session. Drop it locally, get
+            // a fresh one, and retry exactly once. If sessionManager is
+            // nil (legacy callers without session wiring), the original
+            // error propagates — no silent retry.
+            guard let sessionManager else { throw apiError }
+            sessionManager.invalidateCurrentSession()
+            let freshId = try await sessionManager.activeSessionId(apiClient: apiClient)
+            return try await apiClient.ingest(
+                jpegData: jpegData,
+                binId: binId,
+                deviceMetadata: deviceMetadata,
+                sessionId: freshId
+            )
+        }
     }
 }

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -471,7 +471,12 @@ final class AnalysisViewModel {
             // nil (legacy callers without session wiring), the original
             // error propagates — no silent retry.
             guard let sessionManager else { throw apiError }
-            sessionManager.invalidateCurrentSession()
+            // Swift2_019b G-1 / SEC-25-2 — only invalidate if `current`
+            // is still the id that the failing /ingest used. Prevents a
+            // delayed 400 from clobbering a newer legitimate session
+            // (manual End-now, server idle sweep, auto-begin race).
+            logger.info("[SESSION] server returned invalid_session for \(sessionId?.uuidString ?? "nil", privacy: .private) — invalidating and retrying with fresh session")
+            sessionManager.invalidateCurrentSession(ifCurrentIs: sessionId)
             let freshId = try await sessionManager.activeSessionId(apiClient: apiClient)
             return try await apiClient.ingest(
                 jpegData: jpegData,

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -238,12 +238,15 @@ struct BinDetailView: View {
                             // shutter" flow still works. SessionManager
                             // caches the id for subsequent captures and
                             // auto-closes after 30 min of inactivity.
+                            // Swift2_019b — pass the manager so AnalysisViewModel
+                            // can invalidate + retry on 400 invalid_session.
                             let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                             await analysisViewModel.run(
                                 jpegData: rawData,
                                 binId: binId,
                                 apiClient: apiClient,
                                 sessionId: sessionId,
+                                sessionManager: sessionManager,
                                 context: modelContext
                             )
                         }
@@ -328,6 +331,7 @@ struct BinDetailView: View {
                         binId: binId,
                         apiClient: apiClient,
                         sessionId: sessionId,
+                        sessionManager: sessionManager,
                         context: modelContext
                     )
                 }

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -146,12 +146,15 @@ struct BinsListView: View {
                         Task {
                             // Swift2_019 — transparently open a server
                             // session so /ingest passes the new validator.
+                            // Swift2_019b — pass the manager for 400
+                            // invalid_session invalidate + retry.
                             let sessionId = try? await sessionManager.activeSessionId(apiClient: apiClient)
                             await analysisViewModel.run(
                                 jpegData: rawData,
                                 binId: binId,
                                 apiClient: apiClient,
                                 sessionId: sessionId,
+                                sessionManager: sessionManager,
                                 context: modelContext
                             )
                         }
@@ -261,6 +264,7 @@ struct BinsListView: View {
                         binId: binId,
                         apiClient: apiClient,
                         sessionId: sessionId,
+                        sessionManager: sessionManager,
                         context: modelContext
                     )
                 }

--- a/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
+++ b/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
@@ -1,0 +1,250 @@
+// AnalysisViewModelSessionRecoveryTests.swift
+// Bin BrainTests
+//
+// Swift2_019b — F-1 / SEC-24-1. When the server returns
+// 400 invalid_session on /ingest, AnalysisViewModel must:
+//   1. Invalidate the stale cached Session on the SessionManager.
+//   2. Ask the SessionManager for a fresh session (auto-begin).
+//   3. Retry /ingest once with the new session id.
+// Without the fix, the cached session stays populated and every
+// subsequent ingest loops on 400s until the 30-min idle timer or an
+// app restart.
+
+import XCTest
+@testable import Bin_Brain
+
+// MARK: - URLProtocol (distinct per suite)
+
+final class SessionRecoveryMockURLProtocol: URLProtocol {
+    private static let handlerLock = NSLock()
+    nonisolated(unsafe) private static var _handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    static func setHandler(_ handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        _handler = handler
+    }
+
+    static func currentHandler() -> ((URLRequest) throws -> (HTTPURLResponse, Data))? {
+        handlerLock.lock(); defer { handlerLock.unlock() }
+        return _handler
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.currentHandler() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
+
+    var sut: AnalysisViewModel!
+    var sessionManager: SessionManager!
+    var runner: RecordingBackgroundTaskRunner!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        runner = RecordingBackgroundTaskRunner()
+        sut = AnalysisViewModel(backgroundTask: runner)
+        sessionManager = SessionManager()
+    }
+
+    override func tearDown() async throws {
+        SessionRecoveryMockURLProtocol.setHandler(nil)
+        sessionManager.cancelIdleTimer()
+        sessionManager = nil
+        sut = nil
+        runner = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient(
+        handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> APIClient {
+        SessionRecoveryMockURLProtocol.setHandler(handler)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SessionRecoveryMockURLProtocol.self]
+        return APIClient(
+            session: URLSession(configuration: config),
+            keychain: InMemoryKeychainHelper(seeded: ["apiKey": "test-key"])
+        )
+    }
+
+    private func response(_ code: Int, for request: URLRequest) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "http://mock")!,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private func sessionJSON(_ id: UUID) -> Data {
+        Data("""
+        {"session_id":"\(id.uuidString.lowercased())",
+         "started_at":"2026-04-19T12:00:00Z","ended_at":null,
+         "label":null,"photo_count":0}
+        """.utf8)
+    }
+
+    private let invalidSessionErrorJSON = Data("""
+    {"version":"1","error":{"code":"invalid_session",
+     "message":"Session not found, not yours, or already closed"}}
+    """.utf8)
+
+    private let ingestSuccessJSON = Data("""
+    {"version":"1","bin_id":"BIN-0001","photos":[{"photo_id":42,"url":"/photos/42/file"}]}
+    """.utf8)
+
+    private let suggestSuccessJSON = Data("""
+    {"version":"1","photo_id":42,"model":"test-model","vision_elapsed_ms":50,
+     "suggestions":[{"item_id":null,"name":"Widget","category":"Hardware","confidence":0.9,"bins":["BIN-0001"]}]}
+    """.utf8)
+
+    // MARK: - Recovery path
+
+    /// The server rotates/restarts/idles-away the cached session. Next
+    /// ingest gets 400 `invalid_session`. The VM must invalidate, auto-begin
+    /// a fresh session, and retry once — transparently to the user.
+    func testRunInvalidSessionResponseInvalidatesAndRetriesOnceWithFreshSession() async throws {
+        let staleId = UUID()
+        let freshId = UUID()
+
+        // Phase 1 — seed the SessionManager with a stale session. Install
+        // the seed handler FIRST and tear it down before the scenario
+        // handler is installed. The URL protocol has a single static
+        // handler slot; installing a new one replaces the last.
+        sessionManager = SessionManager()
+        let seedClient = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                return (response(201, for: request), sessionJSON(staleId))
+            }
+            return (response(500, for: request), Data())
+        }
+        _ = try await sessionManager.beginSession(apiClient: seedClient)
+        XCTAssertEqual(sessionManager.current?.id, staleId, "precondition: stale session cached")
+
+        // Phase 2 — install the scenario handler AFTER the seed completes.
+        var ingestCount = 0
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON(freshId))
+            }
+            if path == "/ingest" {
+                ingestCount += 1
+                if ingestCount == 1 {
+                    return (response(400, for: request), invalidSessionErrorJSON)
+                }
+                return (response(200, for: request), ingestSuccessJSON)
+            }
+            if path.hasSuffix("/suggest") {
+                return (response(200, for: request), suggestSuccessJSON)
+            }
+            return (response(500, for: request), Data())
+        }
+
+        await sut.run(
+            jpegData: Data("fake-jpeg".utf8),
+            binId: "BIN-0001",
+            apiClient: client,
+            sessionId: staleId,
+            sessionManager: sessionManager
+        )
+
+        XCTAssertEqual(ingestCount, 2,
+                       "VM must retry /ingest exactly once after invalid_session")
+        XCTAssertNotNil(sessionManager.current,
+                        "Fresh session must be auto-begun after invalidation")
+        XCTAssertEqual(sessionManager.current?.id, freshId,
+                       "Retry must use the freshly-minted session, not the stale one")
+        XCTAssertEqual(sut.phase, .complete,
+                       "After successful retry, phase must land on .complete")
+    }
+
+    /// If the retry also fails (e.g. server 500), surface the error
+    /// normally. The VM must not loop indefinitely.
+    func testRunInvalidSessionRetryFailureSurfacesError() async throws {
+        let staleId = UUID()
+        let freshId = UUID()
+
+        // Seed first, install scenario handler second (per the ordering
+        // bug fixed above — the URL protocol has only one handler slot).
+        let seedClient = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                return (response(201, for: request), sessionJSON(staleId))
+            }
+            return (response(500, for: request), Data())
+        }
+        _ = try await sessionManager.beginSession(apiClient: seedClient)
+
+        var ingestCount = 0
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON(freshId))
+            }
+            if path == "/ingest" {
+                ingestCount += 1
+                if ingestCount == 1 {
+                    return (response(400, for: request), invalidSessionErrorJSON)
+                }
+                // Second attempt also fails — different error so the VM
+                // cannot loop on the invalidate-then-retry branch.
+                return (response(500, for: request), Data())
+            }
+            return (response(500, for: request), Data())
+        }
+
+        await sut.run(
+            jpegData: Data("fake-jpeg".utf8),
+            binId: "BIN-0001",
+            apiClient: client,
+            sessionId: staleId,
+            sessionManager: sessionManager
+        )
+
+        XCTAssertEqual(ingestCount, 2, "Must retry exactly once — no infinite loop")
+        if case .failed = sut.phase {
+            // expected
+        } else {
+            XCTFail("Retry failure must surface as .failed, got \(sut.phase)")
+        }
+    }
+}
+
+// MARK: - URLRequest body helper (file-private)
+
+private extension URLRequest {
+    var bodyData: Data? {
+        if let data = httpBody { return data }
+        guard let stream = httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 65_536)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            guard read > 0 else { break }
+            data.append(contentsOf: buffer.prefix(read))
+        }
+        return data
+    }
+}

--- a/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
+++ b/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
@@ -179,6 +179,57 @@ final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
                        "After successful retry, phase must land on .complete")
     }
 
+    /// Swift2_019b G-1 (PR #25 QA). A delayed `invalid_session` 400 for
+    /// a stale in-flight request must not wipe out a newer legitimate
+    /// session that the manager has since advanced to. The recovery
+    /// path now passes `ifCurrentIs: sessionId`; `invalidateCurrentSession`
+    /// no-ops when `current.id != sessionId`.
+    func testRecoveryDoesNotClobberSessionThatChangedDuringIngest() async throws {
+        let staleId = UUID()
+        let newId = UUID()  // NOT the id the client is trying to ingest with
+
+        let seedClient = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                return (response(201, for: request), sessionJSON(newId))
+            }
+            return (response(500, for: request), Data())
+        }
+        // Seed the manager with `newId` — the CURRENT, legitimate session.
+        _ = try await sessionManager.beginSession(apiClient: seedClient)
+        XCTAssertEqual(sessionManager.current?.id, newId, "precondition")
+
+        // Then fire an /ingest that references the STALE id (an in-flight
+        // request from before the session flipped). Server returns
+        // invalid_session for the stale id.
+        var beganCount = 0
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                beganCount += 1
+                return (response(201, for: request), sessionJSON(UUID()))
+            }
+            if path == "/ingest" {
+                return (response(400, for: request), invalidSessionErrorJSON)
+            }
+            return (response(500, for: request), Data())
+        }
+
+        await sut.run(
+            jpegData: Data("fake".utf8),
+            binId: "BIN-0001",
+            apiClient: client,
+            sessionId: staleId,            // ← the in-flight uses the stale id
+            sessionManager: sessionManager
+        )
+
+        XCTAssertEqual(sessionManager.current?.id, newId,
+                       "Recovery must NOT clobber a session-manager session whose id "
+                       + "differs from the id that the /ingest actually used")
+        XCTAssertEqual(beganCount, 0,
+                       "Recovery must not mint a new session when current has already "
+                       + "advanced past the stale id")
+    }
+
     /// If the retry also fails (e.g. server 500), surface the error
     /// normally. The VM must not loop indefinitely.
     func testRunInvalidSessionRetryFailureSurfacesError() async throws {

--- a/Bin Brain/Bin BrainTests/SessionManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/SessionManagerTests.swift
@@ -264,6 +264,33 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNotNil(sut.current, "current must be populated after auto-begin")
     }
 
+    /// Swift2_019b — F-2 / SEC-24-2. Two concurrent callers must coalesce
+    /// into a single `POST /sessions`. Before the fix, `activeSessionId`
+    /// suspends on `await beginSession`; both callers pass the `current
+    /// == nil` gate and both fire a POST, creating orphan sessions that
+    /// count against the server's 20-open cap.
+    func testActiveSessionIdSerializesConcurrentCallers() async throws {
+        var postCount = 0
+        let client = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                postCount += 1
+                return (response(201, for: request), sessionJSON)
+            }
+            return (response(500, for: request), Data())
+        }
+
+        async let a: UUID = sut.activeSessionId(apiClient: client)
+        async let b: UUID = sut.activeSessionId(apiClient: client)
+        async let c: UUID = sut.activeSessionId(apiClient: client)
+        let (ida, idb, idc) = try await (a, b, c)
+
+        XCTAssertEqual(postCount, 1,
+                       "Concurrent activeSessionId callers must coalesce into ONE POST /sessions")
+        XCTAssertEqual(ida, fixedSessionId)
+        XCTAssertEqual(idb, fixedSessionId)
+        XCTAssertEqual(idc, fixedSessionId)
+    }
+
     func testActiveSessionIdReturnsExistingWithoutBeginning() async throws {
         var postCount = 0
         let client = makeClient { [self] request in


### PR DESCRIPTION
## Swift2_019b — SessionManager Reliability Follow-ups (URGENT)

Closes the two reliability gaps QA elevated after PR #24 merged. Both are
reproducible under realistic prod triggers (server key rotation, double-tap
shutter).

Prompt: `.swarm/Prompts/Swift2_019b_session_manager_followups.md` (binbrain repo)
Predecessor: PR #24 — merged at `110e838`.

### F-1 / SEC-24-1 — wire `invalidateCurrentSession()` into ingest recovery

**Before:** `invalidateCurrentSession()` was defined and unit-tested, but **no
production code path called it**. A single 400 `invalid_session` on
`/ingest` (server restart, key rotation, idle sweep from PR #36, etc.) left
the stale UUID cached — every subsequent ingest looped on 400s until app
restart or 30-min local idle. Directly re-opens the iOS-broken window that
PR #24 was meant to close.

**Fix (~40 LOC):** `AnalysisViewModel.run` / `overrideQualityGate` gain an
optional `sessionManager: SessionManager?` parameter. A new static helper
`ingestWithSessionRecovery` wraps the `/ingest` call:

```swift
} catch let apiError as APIError where apiError.error.code == "invalid_session" {
    guard let sessionManager else { throw apiError }
    sessionManager.invalidateCurrentSession(ifCurrentIs: sessionId)
    let freshId = try await sessionManager.activeSessionId(apiClient: apiClient)
    return try await apiClient.ingest(..., sessionId: freshId)   // single retry
}
```

Subsequent failures propagate normally — no infinite loop. Legacy callers
that omit `sessionManager` get the pre-fix behavior (APIError propagates),
so no existing tests need migration.

### F-2 / SEC-24-2 — serialize concurrent `activeSessionId` callers

**Before:** `activeSessionId` had an `await`-gap between the `current == nil`
check and the `current = session` write. Two concurrent first-photo captures
(double-tap shutter, BinsListView/BinDetailView handoff, drain racing first
ingest) both passed the gate and both POSTed `/sessions` — burning server
session quota and creating orphan rows against the 20-open cap.

**Fix (~15 LOC):** memoize the in-flight `beginSession` in a private
`beginTask: Task<Session, Error>?`. Concurrent callers see it and await the
same Task:

```swift
if let existing = current { return existing.id }
if let inflight = beginTask { return try await inflight.value.id }
let task = Task<Session, Error> { try await beginSession(apiClient: apiClient) }
beginTask = task
defer { beginTask = nil }
return try await task.value.id
```

Main-actor isolation guarantees the assignment and first-reader check run
on the same serial queue — no lock required.

### Tests (TDD, URLProtocol-mocked)

- `testActiveSessionIdSerializesConcurrentCallers` — 3 async-let callers
  against a mock that counts POST `/sessions`. Asserts exactly 1 POST, all
  three receive the same id.
- `testRunInvalidSessionResponseInvalidatesAndRetriesOnceWithFreshSession`
  — seeds stale session; first `/ingest` returns 400 `invalid_session`,
  second returns 200. Asserts invalidate fired, new POST `/sessions`
  minted a fresh id, retry used it, phase landed on `.complete`.
- `testRunInvalidSessionRetryFailureSurfacesError` — retry also 500s;
  asserts exactly 2 ingests (no loop) and phase is `.failed`.

All URL traffic through `SessionRecoveryMockURLProtocol` /
`SessionMockURLProtocol` — no real sockets, no prod-DB risk.

### View plumbing

`BinsListView` and `BinDetailView` pass the shared `@Environment
sessionManager` through to both `run` and `overrideQualityGate` call
sites so the recovery path fires in production.

### Deferred (per prompt)

- F-3 / SEC-24-4 — `endSession` failure close-retry queue: ratified as
  documented deferral (plan doc updated).
- SEC-24-3 idle timer wall-clock semantics (F-4 in QA report): defer.
- SEC-24-5/6 INFO findings: defer.
- Settings interaction test (QA finding e): defer.

### Why urgent

Without F-1, any server-side event that invalidates the cached session
re-opens the "every photo 400s" window PR #24 was supposed to close.
Without F-2, heavy/racy use of the shutter or view transitions silently
burns server session quota.

🤖 Generated for Swift2_019b.

---

## Post-review bundle (commit `b6bcea7`)

Bundled G-1 + G-5 per QA + aegis re-review asks. 17 production LOC + 51 test LOC, within the <30/<40 budget.

Reports:
- `.swarm/AssessmentReports/QA_iOS_PR25_041926.md`
- `.swarm/AssessmentReports/SEC_iOS_PR25_041926.md`

### G-1 — conditional `invalidateCurrentSession(ifCurrentIs:)`

Unconditional `invalidateCurrentSession()` could wipe a newer legitimate session whenever a delayed 400 `invalid_session` returned for a stale in-flight id. Real interleaving: `/ingest` dispatches with id A, the manager advances to id B via idle sweep / manual End-now / auto-begin race, the delayed 400 for A triggers recovery, recovery clears B.

Fix: `SessionManager.invalidateCurrentSession` gains an optional `ifCurrentIs staleId: UUID? = nil`. When set and `current?.id != staleId`, the clear is a no-op — B is preserved. Default-nil keeps every existing caller (sign-out flows). `AnalysisViewModel.ingestWithSessionRecovery` passes `ifCurrentIs: sessionId` (the id the failing ingest actually used).

### G-5 / SEC-25-2 — logger breadcrumb

Both reviewers asked for an operational trail. `logger.info("[SESSION] server returned invalid_session for … — invalidating and retrying with fresh session")` at the top of the recovery catch so the event is visible in Console.app without a debugger.

### New test

`testRecoveryDoesNotClobberSessionThatChangedDuringIngest` — seeds manager with `newId`, fires `/ingest` bound to `staleId`, server 400s, recovery runs. Asserts `current.id` stays `newId` and `beganCount == 0` (no phantom POST `/sessions`).

`testInvalidateCurrentSessionClearsWithoutNetworkCall` stays green via the zero-arg default — regression-guarded per prompt.

**506 unit tests pass** (was 505 + 1 new). Other QA/SEC findings (G-2/3/4, SEC-25-1/3/4/5) deferred to Swift2_019c per prompt.
