### PR TITLE
feat(outcomes): crash-reclaim + drain serialization + on-disk tests + idempotency key (Swift2_018b)

### DIFF
--- a/Bin Brain/Bin Brain/Bin_BrainApp.swift
+++ b/Bin Brain/Bin Brain/Bin_BrainApp.swift
@@ -65,6 +65,13 @@ struct Bin_BrainApp: App {
             RootView()
                 .task { await requestNotificationPermission() }
                 .task {
+                    // Swift2_018b F-1 — reclaim any rows left `.sending`
+                    // by a previous process that crashed mid-POST. Must
+                    // run BEFORE the first drain; `startMonitoring` may
+                    // trigger a drain via NWPathMonitor immediately.
+                    outcomeQueueManager.reclaimOrphanedSendingRows(
+                        context: sharedModelContainer.mainContext
+                    )
                     // Swift2_018 — start NWPathMonitor + foreground observer
                     // for the outcomes queue so retries fire automatically
                     // on connectivity recovery. Idempotent.

--- a/Bin Brain/Bin Brain/Services/APIClient.swift
+++ b/Bin Brain/Bin Brain/Services/APIClient.swift
@@ -380,11 +380,18 @@ final class APIClient {
     ///   - body: Already-serialized JSON payload (frozen at enqueue time).
     ///   - clientRetryCount: Value forwarded as `X-Client-Retry-Count` so
     ///     the server can log the number of attempts it took to deliver.
+    ///   - idempotencyKey: Stable client-side UUID forwarded as
+    ///     `Idempotency-Key` (`Swift2_018b` F-6). Every retry for the
+    ///     same `PendingOutcome` row reuses the same value so the server
+    ///     can collapse duplicate attempts once the matching ApiDev PR
+    ///     adds the dedup column. Until that server PR ships, the header
+    ///     is ignored — still safe to send.
     /// - Returns: The HTTP status code returned by the server.
     func postPhotoSuggestionOutcomesRaw(
         photoId: Int,
         body: Data,
-        clientRetryCount: Int
+        clientRetryCount: Int,
+        idempotencyKey: UUID
     ) async throws -> Int {
         guard hasAPIKey else { throw APIClientError.missingAPIKey }
         let urlString = baseURL + "/photos/\(String(photoId).urlPathComponentEncoded)/outcomes"
@@ -396,6 +403,7 @@ final class APIClient {
         urlRequest.httpBody = body
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("\(max(clientRetryCount, 0))", forHTTPHeaderField: "X-Client-Retry-Count")
+        urlRequest.setValue(idempotencyKey.uuidString.lowercased(), forHTTPHeaderField: "Idempotency-Key")
         if let apiKey, shouldAttachKey(requiresAuth: true, probe: false) {
             urlRequest.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
         }

--- a/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
+++ b/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
@@ -190,6 +190,36 @@ final class OutcomeQueueManager {
         refreshCounts(context: context)
     }
 
+    /// Flips every `.sending` row back to `.pending` without touching
+    /// `retryCount`. Call once per process at launch before the first
+    /// `drain(...)` — `Bin_BrainApp` does this.
+    ///
+    /// Swift2_018b F-1 / SEC-23-1: `.sending` rows that the app
+    /// crashed-in-flight previously leaked for 7 days until `expireAged`
+    /// swept them to `.expired` with zero retries. Server is append-only
+    /// (per F-6 client idempotency plan) — a duplicate POST is strictly
+    /// preferable to a dropped training signal, so we do NOT bump
+    /// `retryCount` on reclaim: callers can distinguish "crashed mid
+    /// first attempt" from "retried normally" via the count.
+    func reclaimOrphanedSendingRows(context: ModelContext) {
+        let all: [PendingOutcome]
+        do {
+            all = try context.fetch(FetchDescriptor<PendingOutcome>())
+        } catch {
+            logger.error("[OUTCOMES] reclaim fetch failed: \(error.localizedDescription, privacy: .private)")
+            return
+        }
+        var touched = false
+        for row in all where row.status == .sending {
+            row.status = .pending
+            touched = true
+        }
+        if touched {
+            save(context)
+            refreshCounts(context: context)
+        }
+    }
+
     /// Recomputes `pendingCount`, `deliveredCount`, and `expiredCount`
     /// from the persisted rows. Called after every mutation.
     func refreshCounts(context: ModelContext) {
@@ -284,6 +314,14 @@ final class OutcomeQueueManager {
         context: ModelContext,
         apiClient: APIClient
     ) async {
+        // Swift2_018b F-3 — CAS guard. Concurrent drain triggers
+        // (NWPathMonitor `.satisfied` + willEnterForeground +
+        // scenePhase `.active`) can schedule two `attemptDelivery`
+        // Tasks for the same row. Main-actor isolation guarantees the
+        // check-flip-save below runs to completion between awaits, so
+        // the second task on resumption sees `.sending` and returns
+        // early — only one POST fires.
+        guard row.status == .pending else { return }
         row.status = .sending
         save(context)
 
@@ -293,7 +331,8 @@ final class OutcomeQueueManager {
             status = try await apiClient.postPhotoSuggestionOutcomesRaw(
                 photoId: row.photoId,
                 body: row.payload,
-                clientRetryCount: row.retryCount
+                clientRetryCount: row.retryCount,
+                idempotencyKey: row.id
             )
         } catch let urlError as URLError {
             row.lastErrorCode = urlError.code.rawValue

--- a/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
@@ -399,6 +399,133 @@ final class OutcomeQueueManagerTests: XCTestCase {
                        "Expired rows persist until the user dismisses them explicitly")
     }
 
+    // MARK: - F-1 / SEC-23-1 — crash-in-flight reclaim
+
+    /// Swift2_018b F-1. A row left `.sending` by a crashed-in-flight POST
+    /// must be reclaimed back to `.pending` on the next cold launch so
+    /// the training signal actually retries instead of leaking for 7 days
+    /// until `expireAged` sweeps it as `.expired` with zero attempts.
+    ///
+    /// Reclaim is explicit (`reclaimOrphanedSendingRows(context:)`) and
+    /// one-shot per process — Bin_BrainApp calls it at launch BEFORE the
+    /// first drain. Do NOT increment `retryCount` on reclaim: the server
+    /// might have received the payload before the crash; a duplicate
+    /// beats a loss (server is append-only / idempotent per F-6).
+    func testColdLaunchReclaimsSendingRowsAsPending() async throws {
+        let stuck = PendingOutcome(photoId: 7, payload: samplePayload)
+        stuck.status = .sending
+        stuck.retryCount = 2
+        stuck.nextRetryAt = Date().addingTimeInterval(-1)
+        context.insert(stuck)
+        try context.save()
+
+        var posts = 0
+        let client = makeMockAPIClient { [self] request in
+            posts += 1
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        // Simulate the launch sequence: reclaim first, then drain.
+        sut.reclaimOrphanedSendingRows(context: context)
+        await sut.drain(context: context, apiClient: client)
+
+        XCTAssertEqual(posts, 1,
+                       "Cold-launch reclaim must return the row to .pending so drain retries it")
+        let refreshed = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(refreshed.status, .delivered)
+        XCTAssertEqual(refreshed.retryCount, 2,
+                       "Reclaim must NOT increment retryCount — crash-in-flight ambiguity")
+    }
+
+    // MARK: - F-3 — CAS drain guard
+
+    /// Swift2_018b F-3. NWPathMonitor `.satisfied` + willEnterForeground
+    /// + scenePhase `.active` can all fire in the same few ms, scheduling
+    /// two concurrent `drain()` calls. Both fetch the same `.pending`
+    /// row; without a guard, both flip it to `.sending` and both POST.
+    /// The server (append-only today) then sees two identical outcome
+    /// rows — pure training-signal duplication.
+    ///
+    /// Guard: at the top of `attemptDelivery`, re-check `row.status ==
+    /// .pending` before the flip. Main-actor isolation guarantees the
+    /// check-flip-save runs atomically between awaits; the second drain
+    /// on resumption observes `.sending` and returns early.
+    func testConcurrentDrainsDoNotDoubleSendRow() async throws {
+        let row = PendingOutcome(photoId: 1, payload: samplePayload)
+        row.retryCount = 0
+        row.nextRetryAt = Date().addingTimeInterval(-1)
+        context.insert(row)
+        try context.save()
+
+        var posts = 0
+        let client = makeMockAPIClient { [self] request in
+            posts += 1
+            // Slow response so the second drain starts before the first
+            // returns from the network call. Thread.sleep is legal here —
+            // the URL protocol's startLoading runs on a background queue.
+            Thread.sleep(forTimeInterval: 0.05)
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        async let a: Void = sut.drain(context: context, apiClient: client)
+        async let b: Void = sut.drain(context: context, apiClient: client)
+        _ = await (a, b)
+
+        XCTAssertEqual(posts, 1,
+                       "Two concurrent drains must not double-send the same row — server append-only semantics mean duplicates become bad training signal")
+        let refreshed = try XCTUnwrap(try context.fetch(FetchDescriptor<PendingOutcome>()).first)
+        XCTAssertEqual(refreshed.status, .delivered)
+    }
+
+    // MARK: - F-6 — idempotency key header
+
+    /// Swift2_018b F-6 (client half). Every outcomes POST must carry
+    /// `Idempotency-Key: <PendingOutcome.id UUID>`. Header ships on the
+    /// first attempt; see the retry test for stability across retries.
+    ///
+    /// Server-side dedup is a SEPARATE PR (ApiDev); until it ships, the
+    /// header is a no-op, but we want the client plumbing live so flipping
+    /// the server switch doesn't require an iOS release.
+    func testOutcomePostSendsIdempotencyKeyHeader() async throws {
+        var capturedHeader: String?
+        let client = makeMockAPIClient { [self] request in
+            capturedHeader = request.value(forHTTPHeaderField: "Idempotency-Key")
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.enqueue(photoId: 7, payload: samplePayload, context: context, apiClient: client)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(capturedHeader, row.id.uuidString.lowercased(),
+                       "First POST must carry Idempotency-Key header equal to PendingOutcome.id")
+    }
+
+    /// F-6 retry stability: the second attempt for a row must reuse the
+    /// original UUID so the server can collapse the duplicate. A fresh
+    /// UUID per attempt would make the key useless for dedup.
+    func testOutcomeRetryReusesSameIdempotencyKey() async throws {
+        let row = PendingOutcome(photoId: 11, payload: samplePayload)
+        row.retryCount = 2
+        row.nextRetryAt = Date().addingTimeInterval(-1)
+        context.insert(row)
+        try context.save()
+
+        var seenHeaders: [String] = []
+        let client = makeMockAPIClient { [self] request in
+            if let h = request.value(forHTTPHeaderField: "Idempotency-Key") {
+                seenHeaders.append(h)
+            }
+            return (mockResponse(statusCode: 200, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        XCTAssertEqual(seenHeaders.count, 1, "precondition: one POST")
+        XCTAssertEqual(seenHeaders.first, row.id.uuidString.lowercased(),
+                       "Retry attempts must reuse PendingOutcome.id — otherwise server dedup is useless")
+    }
+
     // MARK: - Observable counts
 
     func testCountsReflectPersistedRows() async throws {

--- a/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
+++ b/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
@@ -113,4 +113,57 @@ final class PendingOutcomeTests: XCTestCase {
         XCTAssertEqual(OutcomeQueueManager.backoff(retryCount: -1), 0,
                        "Negative retryCount defends against corrupt persistence")
     }
+
+    // MARK: - F-5: on-disk persistence round-trip
+
+    /// Swift2_018b F-5. The whole point of the `PendingOutcome` queue is
+    /// that it "survives app termination" (see the file header comment).
+    /// Every prior test uses `isStoredInMemoryOnly: true` — that never
+    /// exercises the SQLite write path, the store-file format, or the
+    /// `@Attribute(.unique)` enforcement. This test creates a file-backed
+    /// `ModelContainer` in a tempdir, writes a row through container1,
+    /// tears container1 down (simulated app exit), opens container2
+    /// against the same URL, and asserts the row is intact.
+    func testRowSurvivesContainerTeardownAndRelaunch() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pendingoutcome-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+            let wal = tempURL.appendingPathExtension("wal")
+            let shm = tempURL.appendingPathExtension("shm")
+            try? FileManager.default.removeItem(at: wal)
+            try? FileManager.default.removeItem(at: shm)
+        }
+
+        // Launch 1 — write a row and tear down.
+        let originalId: UUID
+        do {
+            let schema = Schema([PendingOutcome.self])
+            let config = ModelConfiguration(schema: schema, url: tempURL)
+            let container1 = try ModelContainer(for: schema, configurations: config)
+            let ctx1 = ModelContext(container1)
+            let row = PendingOutcome(photoId: 77, payload: Data("{\"hi\":1}".utf8))
+            row.retryCount = 4
+            originalId = row.id
+            ctx1.insert(row)
+            try ctx1.save()
+            // container1 released when scope ends — simulates app exit.
+        }
+
+        // Launch 2 — open the same on-disk store and fetch the row.
+        let schema = Schema([PendingOutcome.self])
+        let config = ModelConfiguration(schema: schema, url: tempURL)
+        let container2 = try ModelContainer(for: schema, configurations: config)
+        let ctx2 = ModelContext(container2)
+        let rows = try ctx2.fetch(FetchDescriptor<PendingOutcome>())
+
+        XCTAssertEqual(rows.count, 1,
+                       "PendingOutcome must persist across ModelContainer teardown — the queue's whole guarantee")
+        XCTAssertEqual(rows.first?.id, originalId,
+                       "UUID identity must round-trip through SQLite")
+        XCTAssertEqual(rows.first?.photoId, 77)
+        XCTAssertEqual(rows.first?.retryCount, 4)
+        XCTAssertEqual(rows.first?.status, .pending,
+                       "Int raw value of the status enum must round-trip — frozen values per PendingOutcome doc")
+    }
 }


### PR DESCRIPTION
## Swift2_018b — Offline Outcomes Queue Resilience Bundle (2b-γ iOS follow-ups)

Closes the four deferred resilience gaps from PR #23 reviews. Parent PR: #23
(merged at `3ddf1da`). Review reports that drove the scope:
`.swarm/AssessmentReports/QA_iOS_PR23_041926.md` (F-1, F-3, F-5, F-6) and
`.swarm/AssessmentReports/SEC_iOS_PR23_041926.md` (SEC-23-1 overlaps F-1).

## ⚠️ DO NOT MERGE until the server-side F-6 PR ships

The iOS half of **F-6 (idempotency key header)** is live here but the server
dedup column + unique constraint + 2xx-on-duplicate semantics are in a
separate ApiDev PR. Until that lands in prod, the `Idempotency-Key` header is
ignored server-side and retries still create duplicate rows. **Architect has
explicit merge-gate control.** F-1/F-3/F-5 can ship independently; this PR is
structured so reverting the header is a one-line change if the server PR
takes longer than expected.

## What changed

### F-1 / SEC-23-1 — Crash-in-flight reclaim

`OutcomeQueueManager.reclaimOrphanedSendingRows(context:)` flips every
`.sending` row back to `.pending` without touching `retryCount`. Call is
explicit and one-shot per process — `Bin_BrainApp.task` invokes it BEFORE
`startMonitoring` (which can trigger a drain via `NWPathMonitor`). Not called
from `drain` itself — stays a deliberate cold-launch event.

`retryCount` intentionally not bumped: the server may have accepted the
payload before the crash. Per F-6's append-only-with-idempotency-key plan, a
duplicate is strictly preferable to a lost signal.

### F-3 — Drain CAS guard

`attemptDelivery` now opens with `guard row.status == .pending else { return }`
before the `.sending` flip + save. Main-actor isolation guarantees the
check-flip-save runs atomically between awaits, so two concurrent drains
(NWPathMonitor `.satisfied` + willEnterForeground + scenePhase `.active` all
racing) produce exactly one POST. The second on resumption sees `.sending`
and returns early. Follows QA F-3 Option C — cheap, no long-lived lock.

### F-5 — On-disk SwiftData round-trip

`PendingOutcomeTests.testRowSurvivesContainerTeardownAndRelaunch` opens a
file-backed `ModelContainer` in a tempdir, writes a `.pending` row through
container1, tears container1 down (simulates app exit), opens container2
against the same URL, and asserts the row fetches back with id, photoId,
retryCount, and status intact. Real SQLite I/O — exercises the `@Model`
attribute declarations and the status enum's Int raw value stability for the
first time.

### F-6 — Client-side idempotency key (HOLD for merge)

`APIClient.postPhotoSuggestionOutcomesRaw(…, idempotencyKey: UUID)` sets
`Idempotency-Key: <PendingOutcome.id>` on every attempt. Retries for the
same row reuse the id so the server can collapse duplicates once the
matching dedup column is live. Tests assert:

- `testOutcomePostSendsIdempotencyKeyHeader` — first POST carries the header
  equal to `PendingOutcome.id.uuidString.lowercased()`.
- `testOutcomeRetryReusesSameIdempotencyKey` — retry on a pre-seeded
  `retryCount=2` row emits the same UUID, not a fresh one.

## Tests

All 5 new tests green on iPhone 17 simulator. URLProtocol mocks throughout
— no real sockets, no prod-DB risk.

- `testColdLaunchReclaimsSendingRowsAsPending`
- `testConcurrentDrainsDoNotDoubleSendRow`
- `testOutcomePostSendsIdempotencyKeyHeader`
- `testOutcomeRetryReusesSameIdempotencyKey`
- `testRowSurvivesContainerTeardownAndRelaunch` (on-disk)

**Full unit suite: 510 tests green.**

## Size

58 prod LOC + 180 test LOC — well within the <400 prod / <600 test budget
in the prompt.

## Out of scope (per prompt)

- Server-side idempotency column + dedup logic — separate ApiDev PR.
- UploadQueueManager drain-serialization consistency — noted for future
  hardening; not touched here.
- F-2 and F-4 — landed inside PR #23.
- F-7 through F-11 — deferred hardening pass.
- `Retry-After` header parsing, payload refresh on retry, timeout tuning.

🤖 Generated for Swift2_018b.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup to recover photo outcome submissions interrupted by crashes, automatically resetting pending uploads to ensure proper retry.

* **Tests**
  * Added comprehensive test coverage for queue recovery, concurrent delivery operations, and HTTP idempotency validation in upload requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->