### PR TITLE
fix(quality): union saliency bboxes so multi-object captures aren't cropped (Swift2_024)

### DIFF
--- a/Bin Brain/Bin Brain/Services/Pipeline/QualityGates.swift
+++ b/Bin Brain/Bin Brain/Services/Pipeline/QualityGates.swift
@@ -403,15 +403,16 @@ nonisolated struct QualityGates: Sendable {
                     return
                 }
 
-                // Compute total coverage as union of all salient bounding boxes (simplified)
-                // Use the largest bounding box as the primary region
-                let largestObject = salientObjects.max(by: {
-                    $0.boundingBox.width * $0.boundingBox.height < $1.boundingBox.width * $1.boundingBox.height
-                })!
-
-                let coverage = Double(largestObject.boundingBox.width * largestObject.boundingBox.height)
-
-                continuation.resume(returning: (coverage, largestObject.boundingBox, nil))
+                // Swift2_024 — union of every salient object's bbox, not just
+                // the largest. The previous "pick largest" pruned the upload
+                // crop to a single subject; a screwdriver next to two NFC tags
+                // had the screwdriver stripped before /ingest because the
+                // higher-contrast tags were the largest single object.
+                // TODO(Swift2_024-followup): expose a margin / crop-disable
+                // toggle if union proves insufficient in the wild.
+                let unionBox = Self.unionBoundingBox(of: salientObjects.map { $0.boundingBox })!
+                let coverage = Double(unionBox.width * unionBox.height)
+                continuation.resume(returning: (coverage, unionBox, nil))
             }
         }
     }
@@ -425,6 +426,22 @@ nonisolated struct QualityGates: Sendable {
     func checkSaliencyOnly(_ cgImage: CGImage) async throws -> CGRect? {
         let result = try await checkSaliency(cgImage)
         return result.boundingBox
+    }
+
+    /// Pure reduction over a list of normalized salient bounding boxes.
+    ///
+    /// Returns the smallest rectangle that fully contains every input bbox
+    /// (`CGRect.union` over all elements), or `nil` for an empty input.
+    /// Extracted so the multi-object union logic in `checkSaliency` can be
+    /// unit-tested without a Vision dependency (`Swift2_024`).
+    ///
+    /// - Parameter bboxes: Normalized 0...1 bounding boxes from
+    ///   `VNRectangleObservation` (or any geometric source — the function is
+    ///   agnostic).
+    /// - Returns: The union rectangle, or `nil` if `bboxes` is empty.
+    static func unionBoundingBox(of bboxes: [CGRect]) -> CGRect? {
+        guard let first = bboxes.first else { return nil }
+        return bboxes.dropFirst().reduce(first) { $0.union($1) }
     }
 
     // MARK: - Helpers

--- a/Bin Brain/Bin BrainTests/QualityGatesTests.swift
+++ b/Bin Brain/Bin BrainTests/QualityGatesTests.swift
@@ -339,4 +339,55 @@ final class QualityGatesTests: XCTestCase {
         XCTAssertEqual(result.scores.exposureMean, 0, "Exposure should not be computed when resolution fails")
         XCTAssertEqual(result.scores.saliencyCoverage, 0, "Saliency should not be computed when resolution fails")
     }
+
+    // MARK: - Swift2_024 — saliency union-bbox helper
+
+    /// Empty input → nil. Preserves the existing "no salient objects" path
+    /// in `checkSaliency` (no crop applied, full frame uploaded).
+    func testUnionBoundingBoxReturnsNilForEmptyInput() {
+        XCTAssertNil(QualityGates.unionBoundingBox(of: []))
+    }
+
+    /// Single object → that object's bbox unchanged. Verifies the new union
+    /// path doesn't regress single-subject captures (the common case).
+    func testUnionBoundingBoxReturnsSingleBboxUnchanged() {
+        let only = CGRect(x: 0.2, y: 0.3, width: 0.4, height: 0.5)
+        XCTAssertEqual(QualityGates.unionBoundingBox(of: [only]), only)
+    }
+
+    /// Two non-overlapping objects (top-half + bottom-half of frame) → union
+    /// must contain both. This is the regression bug Stephen reproduced
+    /// (screwdriver + two NFC tags) — the older "pick largest" path would
+    /// have returned only the bigger of the two boxes, stripping the other
+    /// from the upload crop.
+    func testUnionBoundingBoxFullyContainsAllNonOverlappingBoxes() {
+        let topBox = CGRect(x: 0.1, y: 0.6, width: 0.2, height: 0.2)
+        let bottomBox = CGRect(x: 0.7, y: 0.1, width: 0.2, height: 0.2)
+
+        let union = QualityGates.unionBoundingBox(of: [topBox, bottomBox])
+
+        XCTAssertEqual(union, topBox.union(bottomBox))
+        XCTAssertTrue(union?.contains(topBox) ?? false,
+                      "Union must fully contain the first object's bbox")
+        XCTAssertTrue(union?.contains(bottomBox) ?? false,
+                      "Union must fully contain the second object's bbox — this is the screwdriver-stripping regression")
+    }
+
+    /// Three objects, two overlapping. CGRect.union handles overlap via the
+    /// minimum-enclosing-rect rule, so no double-counting occurs and the
+    /// result still contains every input.
+    func testUnionBoundingBoxMergesOverlappingBoxesWithoutDoubleCounting() {
+        let a = CGRect(x: 0.10, y: 0.10, width: 0.30, height: 0.30) // 0.10–0.40
+        let b = CGRect(x: 0.30, y: 0.30, width: 0.30, height: 0.30) // 0.30–0.60 (overlaps a)
+        let c = CGRect(x: 0.70, y: 0.70, width: 0.10, height: 0.10) // 0.70–0.80 (separate)
+
+        let union = QualityGates.unionBoundingBox(of: [a, b, c])
+
+        let expected = a.union(b).union(c)
+        XCTAssertEqual(union, expected)
+        XCTAssertEqual(union?.minX ?? 0, 0.10, accuracy: 1e-9)
+        XCTAssertEqual(union?.minY ?? 0, 0.10, accuracy: 1e-9)
+        XCTAssertEqual(union?.maxX ?? 0, 0.80, accuracy: 1e-9)
+        XCTAssertEqual(union?.maxY ?? 0, 0.80, accuracy: 1e-9)
+    }
 }


### PR DESCRIPTION
## The bug

User captured a photo with a screwdriver + two NFC-tag stickers on carpet. The uploaded JPEG contained only the NFC-tag region; the screwdriver was cropped out before `/ingest` ever saw it. Review screen reflects the cropped upload, not the original framing.

## Root cause

`Services/Pipeline/QualityGates.swift` `checkSaliency` selected the **single largest** `VNRectangleObservation` from the saliency request and passed its bbox forward. `ImageOptimizer.optimize(_:saliencyBoundingBox:)` then cropped the JPEG to that bbox, discarding everything outside — so any subject Vision didn't pick as the largest object was stripped before upload.

Vision latched onto the high-contrast NFC tags as the largest single object; the screwdriver lived outside that bbox.

## The fix

Replace "pick largest" with the **union of every salient object's bbox** via a new pure static helper:

```swift
static func unionBoundingBox(of bboxes: [CGRect]) -> CGRect? {
    guard let first = bboxes.first else { return nil }
    return bboxes.dropFirst().reduce(first) { $0.union($1) }
}
```

`checkSaliency` now reduces all `salientObjects.map { $0.boundingBox }` through this helper. `checkSaliencyOnly` is unchanged — it already delegates to `checkSaliency`, so the fix flows through both call sites.

## Behaviour preserved

- **No salient objects:** existing early-return path unchanged (no crop applied, full frame uploaded).
- **Single object:** union collapses to that bbox — identical to today.
- **Multi-object overlap:** `CGRect.union` handles overlap correctly via min-enclosing-rect; no double-counting.
- **Coverage metric:** still derived from the returned bbox area (`width * height`), now over the union — semantically a stronger hint, not a regression of the threshold.

A `TODO(Swift2_024-followup)` records the open thread on a future margin / crop-disable toggle if union proves insufficient in the wild.

## Tests

Pure helper-level — no Vision dependency in the test (per the prompt's preference):

1. Empty input → `nil`.
2. Single bbox → unchanged.
3. Two non-overlapping bboxes → union fully contains both. **This is the regression scenario** (Stephen's screwdriver + NFC-tag photo).
4. Three bboxes with overlap → matches `a.union(b).union(c)` and exact min/max bounds (`0.10 → 0.80`).

**Full unit suite: 525/525 green, zero warnings.**

## Out of scope (per prompt)

- Disabling crop entirely (design discussion).
- Padding the union by a configurable margin.
- `ImageOptimizer` / upload plumbing changes.
- Server-side `/associate` quantity-collapse bug (Architect dispatching ApiDev separately).

## Prompt / size

- Prompt: `binbrain/.swarm/Prompts/Swift2_024_fix_saliency_crop_excluding_items.md`
- Diff: +77 / -9 (26 prod + 51 test LOC) — within the <40 prod + <80 test budget.

## Reviewer instructions

Standard cadence per the prompt: aegis SEC + QA in parallel. Architect waits for **both** before merging (PR #24 lesson).
