### PR TITLE
debug(pipeline): log saliency objects + crop decisions to diagnose multi-subject photos (Swift2_026)

### DIFF
--- a/Bin Brain/Bin Brain/Services/Pipeline/ImageOptimizer.swift
+++ b/Bin Brain/Bin Brain/Services/Pipeline/ImageOptimizer.swift
@@ -8,7 +8,15 @@ import Foundation
 import CoreGraphics
 import CoreImage
 import ImageIO
+import OSLog
 import UniformTypeIdentifiers
+
+/// Crop-debug logger — same subsystem/category as `cropDebugLogger` in
+/// `QualityGates.swift`. Filter Console.app with
+/// `subsystem:com.binbrain.app category:crop-debug` to see the full
+/// per-photo trace: salient objects → union → coverage check → final
+/// pixel crop rect → output dims.
+nonisolated private let optimizerCropLogger = Logger(subsystem: "com.binbrain.app", category: "crop-debug")
 
 // MARK: - Image Optimizer
 
@@ -59,6 +67,7 @@ nonisolated struct ImageOptimizer: Sendable {
         var cropInfo: CropInfo?
 
         // Stage 1: Smart crop
+        optimizerCropLogger.notice("[optimize] in image=\(imageWidth, privacy: .public)x\(imageHeight, privacy: .public) bbox=\(saliencyBoundingBox.map { "(\($0.origin.x),\($0.origin.y),\($0.width),\($0.height))" } ?? "nil", privacy: .public)")
         if let box = saliencyBoundingBox {
             let coverage = box.width * box.height
             if coverage < Self.cropThreshold {
@@ -67,6 +76,7 @@ nonisolated struct ImageOptimizer: Sendable {
                     imageWidth: imageWidth,
                     imageHeight: imageHeight
                 )
+                optimizerCropLogger.notice("[optimize] coverage=\(coverage, privacy: .public) < threshold=\(Self.cropThreshold, privacy: .public) → CROPPING to pixelRect=(x=\(cropRect.origin.x, privacy: .public), y=\(cropRect.origin.y, privacy: .public), w=\(cropRect.width, privacy: .public), h=\(cropRect.height, privacy: .public)) padding=\(Self.cropPadding, privacy: .public)")
                 if let cropped = cgImage.cropping(to: cropRect) {
                     cropInfo = CropInfo(
                         originalSize: [imageWidth, imageHeight],
@@ -78,8 +88,15 @@ nonisolated struct ImageOptimizer: Sendable {
                         ]
                     )
                     currentImage = cropped
+                    optimizerCropLogger.notice("[optimize] cropped result=\(cropped.width, privacy: .public)x\(cropped.height, privacy: .public)")
+                } else {
+                    optimizerCropLogger.error("[optimize] cgImage.cropping(to:) returned nil — pixelRect may be out of bounds; uploading uncropped frame")
                 }
+            } else {
+                optimizerCropLogger.notice("[optimize] coverage=\(coverage, privacy: .public) ≥ threshold=\(Self.cropThreshold, privacy: .public) → SKIP crop, full frame")
             }
+        } else {
+            optimizerCropLogger.notice("[optimize] no saliency bbox → SKIP crop, full frame")
         }
 
         // Stage 2: Auto-enhance (disabled by default)
@@ -101,6 +118,7 @@ nonisolated struct ImageOptimizer: Sendable {
         // Stage 4: Render and JPEG encode
         let renderedImage = renderToCGImage(ciImage: ciImage, context: context) ?? currentImage
         let jpegData = encodeJPEG(renderedImage)
+        optimizerCropLogger.notice("[optimize] out image=\(renderedImage.width, privacy: .public)x\(renderedImage.height, privacy: .public) jpeg=\(jpegData.count, privacy: .public)B")
 
         return (jpegData: jpegData, cropInfo: cropInfo)
     }

--- a/Bin Brain/Bin Brain/Services/Pipeline/QualityGates.swift
+++ b/Bin Brain/Bin Brain/Services/Pipeline/QualityGates.swift
@@ -17,6 +17,13 @@ import OSLog
 /// `Logger` is `Sendable`, so a plain `let` is safe from nonisolated contexts.
 nonisolated private let blurGateLogger = Logger(subsystem: "com.binbrain.app", category: "quality")
 
+/// Dedicated logger for the crop pipeline (Vision saliency → ImageOptimizer).
+/// Filter in Console.app with `subsystem:com.binbrain.app category:crop-debug`
+/// to see per-photo: salient-object count, every Vision bbox, the computed
+/// union, coverage vs threshold, and the final pixel crop rect. Geometric
+/// data only — no PII — so values are logged with `privacy: .public`.
+nonisolated let cropDebugLogger = Logger(subsystem: "com.binbrain.app", category: "crop-debug")
+
 // MARK: - Thresholds
 
 /// Blur detection threshold for a 1024px shortest side.
@@ -399,8 +406,17 @@ nonisolated struct QualityGates: Sendable {
 
                 let salientObjects = observation.salientObjects ?? []
                 if salientObjects.isEmpty {
+                    cropDebugLogger.notice("[saliency] image=\(cgImage.width, privacy: .public)x\(cgImage.height, privacy: .public) objects=0 → no bbox, full frame uploaded")
                     continuation.resume(returning: (0, nil, noObjectsFailure))
                     return
+                }
+
+                // Per-object dump: helps confirm whether Vision actually
+                // saw every user-framed subject. If a subject is missing
+                // from this list, the union fix can't recover it.
+                for (i, obj) in salientObjects.enumerated() {
+                    let b = obj.boundingBox
+                    cropDebugLogger.notice("[saliency] object \(i, privacy: .public)/\(salientObjects.count, privacy: .public): bbox=(x=\(b.origin.x, privacy: .public), y=\(b.origin.y, privacy: .public), w=\(b.width, privacy: .public), h=\(b.height, privacy: .public)) confidence=\(obj.confidence, privacy: .public)")
                 }
 
                 // Swift2_024 — union of every salient object's bbox, not just
@@ -412,6 +428,7 @@ nonisolated struct QualityGates: Sendable {
                 // toggle if union proves insufficient in the wild.
                 let unionBox = Self.unionBoundingBox(of: salientObjects.map { $0.boundingBox })!
                 let coverage = Double(unionBox.width * unionBox.height)
+                cropDebugLogger.notice("[saliency] image=\(cgImage.width, privacy: .public)x\(cgImage.height, privacy: .public) objects=\(salientObjects.count, privacy: .public) union=(x=\(unionBox.origin.x, privacy: .public), y=\(unionBox.origin.y, privacy: .public), w=\(unionBox.width, privacy: .public), h=\(unionBox.height, privacy: .public)) coverage=\(coverage, privacy: .public)")
                 continuation.resume(returning: (coverage, unionBox, nil))
             }
         }


### PR DESCRIPTION
## Why

Stephen reports that PR #28 (Swift2_024 union-bbox) didn't fully solve the multi-subject crop bug — subjects are still going missing pre-`/ingest`. Three plausible remaining causes can't be distinguished without device data:

1. **Vision misses the unsalient subject entirely** — the screwdriver may simply not be in `salientObjects`, so no union can recover it.
2. **Coverage threshold (0.60) skipping crop, OR padding (0.15 of bbox size) clamping a small union too tight.**
3. **Crop math bug** — Y-flip / clamping in `pixelCropRect` could be returning a rect that doesn't match the user-framed region.

## What this PR adds

OSLog instrumentation only — **zero behaviour change**. Filter Console.app with:

```
subsystem:com.binbrain.app category:crop-debug
```

After the next reproducer photo, that filter shows:

```
[saliency] object 0/3: bbox=(x=0.12, y=0.30, w=0.18, h=0.22) confidence=0.85
[saliency] object 1/3: bbox=(x=0.55, y=0.45, w=0.10, h=0.08) confidence=0.62
[saliency] object 2/3: bbox=(x=0.62, y=0.51, w=0.09, h=0.07) confidence=0.58
[saliency] image=4032x3024 objects=3 union=(x=0.12, y=0.30, w=0.59, h=0.28) coverage=0.165
[optimize] in image=4032x3024 bbox=(0.12,0.30,0.59,0.28)
[optimize] coverage=0.165 < threshold=0.6 → CROPPING to pixelRect=(x=410, y=2106, w=2738, h=979) padding=0.15
[optimize] cropped result=2738x979
[optimize] out image=2048x732 jpeg=287654B
```

That trace tells us instantly which of the three causes above is firing.

## Notes

- All values logged with `privacy: .public` — geometric only, no PII.
- Loggers are `nonisolated let` to match the existing `blurGateLogger` pattern (both files are `nonisolated struct`).
- Each crop branch (cropped / skipped-by-coverage / no-bbox / `cropping(to:)` returned nil) logs distinctly so we can see exactly which path executed.

## Tests

- Full unit suite: **525/525 green, zero new warnings.**
- No new tests — instrumentation only; nothing functionally testable.

## Disposition

This is a **debug aid**, not a fix. After we capture a Console.app trace from Stephen's reproducer, we'll open a follow-up PR that:
- Strips this logging (or wraps it `#if DEBUG`),
- And applies the actual remediation (likely tweaking padding / coverage threshold, or short-circuiting the crop entirely if Vision returns < N objects).

Architect: feel free to merge fast for the debug capture; can skip SEC since it's logger-only and matches the existing privacy convention. Or hold for normal cadence — your call.

## Prompt / size

- No prompt — instrumentation requested directly by Stephen ("put some debugging in the crop process").
- Diff: +35 / -0 LOC, two files.
