### PR TITLE
fix(cataloging): pop inner NavigationStack before tearing down cover so Dismiss returns to bin (Swift2_027)

### DIFF
--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -359,6 +359,14 @@ struct BinDetailView: View {
             viewModel: reviewViewModel,
             apiClient: apiClient,
             onDone: {
+                // Swift2_027 — pop the inner NavigationStack FIRST so the
+                // .analysis/.review pushes unwind before the fullScreenCover
+                // tears down. resetCataloging() (cover's onDismiss) also
+                // clears the path, but it runs *after* the cover has finished
+                // dismissing — too late to prevent SwiftUI rendering a blank
+                // intermediate frame with just the parent's back arrow when
+                // the user taps Dismiss on a preliminary-only result.
+                catalogingPath = []
                 showCamera = false
                 Task { await viewModel.load(binId: binId, apiClient: apiClient) }
             },

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -288,6 +288,14 @@ struct BinsListView: View {
             viewModel: reviewViewModel,
             apiClient: apiClient,
             onDone: {
+                // Swift2_027 — pop the inner NavigationStack FIRST so the
+                // .analysis/.review pushes unwind before the fullScreenCover
+                // tears down. resetCataloging() (cover's onDismiss) also
+                // clears the path, but it runs *after* the cover has finished
+                // dismissing — too late to prevent SwiftUI rendering a blank
+                // intermediate frame with just the parent's back arrow when
+                // the user taps Dismiss on a preliminary-only result.
+                catalogingPath = []
                 showCataloging = false
                 Task { await viewModel.load(apiClient: apiClient) }
             },


### PR DESCRIPTION
## The bug

Capture a photo whose results are only preliminary/low-confidence classifications → `SuggestionReviewView`'s forward button switches from "Confirm" to **"Dismiss"** → user taps Dismiss → lands on a blank screen with just a `<` back arrow instead of returning to `BinDetailView` / `BinsListView`.

## Investigation

Both presenters are structured identically:

```
fullScreenCover(isPresented: $showCamera, onDismiss: resetCataloging) {
    NavigationStack(path: $catalogingPath) {
        ScannerView…
            .navigationDestination(for: CatalogingStep.self) { step in
                case .analysis: AnalysisInProgressView…
                case .review:   SuggestionReviewView(onDone: { … })
            }
    }
}
```

The Dismiss button at `SuggestionReviewView.swift:215` calls `onDone()`. Both presenters' `onDone` closures previously did:

```swift
onDone: {
    showCamera = false   // (or showCataloging = false)
    Task { await viewModel.load(…) }
}
```

That flip dismisses the cover, but at the moment of dismissal the inner `NavigationStack` still has `.analysis` and `.review` pushed on the path. The cover's `onDismiss` (`resetCataloging`) does clear `catalogingPath = []`, but it runs **after** the cover finishes animating away — too late. SwiftUI renders a blank intermediate frame whose only chrome is the parent's back arrow.

**Hypothesis: H1.** Inner NavigationStack push isn't popped when the cover's `isPresented` flips to false.

## Fix (Pattern A)

Clear `catalogingPath = []` **before** flipping the cover binding. Both presenters get the same change:

```swift
onDone: {
    catalogingPath = []   // NEW — pop .analysis/.review off the inner stack first
    showCamera = false    // then dismiss the cover
    Task { await viewModel.load(…) }
}
```

`resetCataloging()` (the cover's `onDismiss`) still clears the path again as belt-and-braces; the new pre-clear just guarantees the order so the inner stack unwinds before the cover.

## Behaviour preserved

- **Confirm** path is unchanged — only the `Dismiss` failure mode is touched.
- `resetCataloging()` is unchanged.
- The reload `Task` still runs.
- Both presenters use the same fix shape so the Dismiss UX is identical from BinsListView and BinDetailView.

## Tests

This is a SwiftUI navigation-lifecycle bug — not directly unit-testable without a UI-snapshot harness (which the project doesn't carry for this view).

- **Regression:** full `Bin BrainTests` target — **525/525 green, zero new warnings.**
- **Manual reproducer:** capture a photo that yields only preliminary classifications (or otherwise force everything to be excluded so the button reads "Dismiss"). Tap Dismiss. **Before:** blank screen with back arrow. **After:** lands cleanly on `BinDetailView` / `BinsListView`. Run from both presenters because the bug existed on both code paths.

## Out of scope (per prompt)

- Restructuring the cataloging NavigationStack architecture.
- Changing `resetCataloging()` semantics.
- Changing the Confirm path.
- Changing the conditions that toggle the "Dismiss" vs "Confirm" button text.

## Prompt / size

- Prompt: `binbrain/.swarm/Prompts/Swift2_027_fix_dismiss_returns_to_blank.md`
- Diff: +16 / -0 (1 LOC + comment per call site, two presenters) — well under the <60 prod budget.

## Reviewer instructions

Standard cadence: aegis SEC + QA in parallel, Architect waits for **both** before merging.
