### PR TITLE
feat(bins): pre-flight reject reserved bin names + map server reserved_bin_name (Swift2_023)

### DIFF
--- a/Bin Brain/Bin Brain/Models/BinNameValidator.swift
+++ b/Bin Brain/Bin Brain/Models/BinNameValidator.swift
@@ -1,0 +1,43 @@
+// BinNameValidator.swift
+// Bin Brain
+//
+// Pre-flight UX guard for bin names that the server reserves for its own
+// sentinels. Mirrors the server's casefolded reserved set (ApiDev_011,
+// HTTP 400 with error code `reserved_bin_name`) so the user gets an inline
+// error without a network round-trip when they enter or scan one of these.
+
+import Foundation
+
+// MARK: - BinNameValidator
+
+/// Pure validator for user-supplied bin names.
+///
+/// The server is the authority on reserved names. This struct mirrors the
+/// server's set so iOS can reject before dispatching the request and surface
+/// a friendlier message than the raw HTTP error path.
+struct BinNameValidator {
+
+    /// Canonical reserved names — kept in sync with the server's casefolded
+    /// set (ApiDev_011). If a new reserved name is added on the server side,
+    /// mirror it here too. Server is authoritative; this set exists only to
+    /// avoid a guaranteed-failure round-trip on the client.
+    static let reservedNames: Set<String> = ["unassigned", "binless"]
+
+    /// Returns `true` if `raw`, after whitespace-trim and ASCII-lowercase,
+    /// matches a reserved bin name. Empty / whitespace-only inputs return
+    /// `false` — those fail other validators (e.g. the QR pattern check)
+    /// for unrelated reasons.
+    static func isReserved(_ raw: String) -> Bool {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return reservedNames.contains(normalized)
+    }
+
+    /// User-facing copy used both pre-flight (scanner / form) and as the
+    /// remap target when the server's `reserved_bin_name` error somehow
+    /// reaches the ingest path. Single source of truth so the message stays
+    /// identical on both code paths.
+    static func friendlyMessage(for raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "'\(trimmed)' is a reserved name. Please choose a different bin name."
+    }
+}

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -465,6 +465,19 @@ final class AnalysisViewModel {
                 deviceMetadata: deviceMetadata,
                 sessionId: sessionId
             )
+        } catch let apiError as APIError where apiError.error.code == "reserved_bin_name" {
+            // Swift2_023 — pre-flight (ScannerViewModel + any future create
+            // form) should have rejected this before we got here. If the
+            // server still rejects, remap the message to the same friendly
+            // copy the pre-flight uses so the user sees one consistent
+            // explanation regardless of which validator caught it.
+            throw APIError(
+                version: apiError.version,
+                error: APIError.ErrorDetail(
+                    code: apiError.error.code,
+                    message: BinNameValidator.friendlyMessage(for: binId)
+                )
+            )
         } catch let apiError as APIError where apiError.error.code == "invalid_session" {
             // Server invalidated our cached session. Drop it locally, get
             // a fresh one, and retry exactly once. If sessionManager is

--- a/Bin Brain/Bin Brain/ViewModels/ScannerViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/ScannerViewModel.swift
@@ -103,6 +103,16 @@ final class ScannerViewModel {
             scanError = "QR payload doesn't match expected bin-id format"
             return
         }
+        // Swift2_023 — reject reserved bin names (UNASSIGNED, Binless) before
+        // they ever reach the scan HUD or the /ingest call. Server (ApiDev_011)
+        // is authoritative; this client check is pre-flight UX so the user
+        // doesn't see the raw token flash on screen and so we never round-trip
+        // a guaranteed-failure name. Closes QA PR #27 observation O-1.
+        guard !BinNameValidator.isReserved(trimmed) else {
+            logger.warning("Rejected QR payload: reserved bin name")
+            scanError = "This QR encodes a reserved bin name and was ignored."
+            return
+        }
         scanError = nil
         scannedBinId = trimmed
         phase = .awaitingPhoto

--- a/Bin Brain/Bin BrainTests/BinNameValidatorTests.swift
+++ b/Bin Brain/Bin BrainTests/BinNameValidatorTests.swift
@@ -1,0 +1,68 @@
+// BinNameValidatorTests.swift
+// Bin BrainTests
+//
+// XCTest coverage for BinNameValidator.swift (Swift2_023). The validator is
+// pure — no async, no I/O, no Vision — so this is straight assertion table.
+
+import XCTest
+@testable import Bin_Brain
+
+final class BinNameValidatorTests: XCTestCase {
+
+    // MARK: - Truthy: must be rejected as reserved
+
+    func testCaseInsensitiveUnassignedVariantsAreReserved() {
+        XCTAssertTrue(BinNameValidator.isReserved("UNASSIGNED"))
+        XCTAssertTrue(BinNameValidator.isReserved("unassigned"))
+        XCTAssertTrue(BinNameValidator.isReserved("Unassigned"))
+        XCTAssertTrue(BinNameValidator.isReserved("uNaSsIgNeD"))
+    }
+
+    func testCaseInsensitiveBinlessVariantsAreReserved() {
+        XCTAssertTrue(BinNameValidator.isReserved("Binless"))
+        XCTAssertTrue(BinNameValidator.isReserved("BINLESS"))
+        XCTAssertTrue(BinNameValidator.isReserved("binless"))
+    }
+
+    func testWhitespaceTrimmingMatchesReservedNames() {
+        XCTAssertTrue(BinNameValidator.isReserved("  UNASSIGNED  "),
+                      "Leading/trailing whitespace must be trimmed before the reserved-set check")
+        XCTAssertTrue(BinNameValidator.isReserved("Binless\n"),
+                      "Trailing newline must be trimmed too — paste-from-clipboard often carries them")
+        XCTAssertTrue(BinNameValidator.isReserved("\tunassigned\t"))
+    }
+
+    // MARK: - Falsy: must NOT be rejected
+
+    func testCommonNonReservedNamesArePermitted() {
+        XCTAssertFalse(BinNameValidator.isReserved("kitchen"))
+        XCTAssertFalse(BinNameValidator.isReserved("BIN-0001"))
+        XCTAssertFalse(BinNameValidator.isReserved("garage-shelf-A"))
+    }
+
+    func testEmptyAndWhitespaceOnlyAreNotReserved() {
+        // These fail other validators (QR pattern, form non-empty), but the
+        // reserved-name check is orthogonal — it answers "is this exact name
+        // on the reserved list?", not "is this name valid?".
+        XCTAssertFalse(BinNameValidator.isReserved(""))
+        XCTAssertFalse(BinNameValidator.isReserved(" "))
+        XCTAssertFalse(BinNameValidator.isReserved("\n\t"))
+    }
+
+    func testSubstringsContainingReservedTokenAreNotReserved() {
+        // The match is exact-after-normalize, not substring — names that
+        // *contain* "unassigned" must pass.
+        XCTAssertFalse(BinNameValidator.isReserved("unassigned-tools"))
+        XCTAssertFalse(BinNameValidator.isReserved("my binless bin"))
+    }
+
+    // MARK: - Friendly message
+
+    func testFriendlyMessageNamesTheTrimmedInput() {
+        let msg = BinNameValidator.friendlyMessage(for: "  UNASSIGNED  ")
+        XCTAssertTrue(msg.contains("'UNASSIGNED'"),
+                      "Message must quote the user's input verbatim (after trim) so they see what was rejected")
+        XCTAssertTrue(msg.contains("reserved"),
+                      "Message must explain why the name was rejected")
+    }
+}

--- a/Bin Brain/Bin BrainTests/ScannerViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/ScannerViewModelTests.swift
@@ -231,4 +231,46 @@ final class ScannerViewModelTests: XCTestCase {
         XCTAssertEqual(haptic.count, 1,
                        "Duplicate QR events after the first success must NOT re-fire the haptic")
     }
+
+    // MARK: - Swift2_023 — reserved bin name pre-flight
+
+    /// A QR encoding the reserved sentinel must be rejected before reaching
+    /// `scannedBinId` or transitioning to `.awaitingPhoto`. Closes QA PR #27
+    /// observation O-1 (raw "UNASSIGNED" displayed in scan HUD).
+    func testReservedBinNameQRDoesNotAdvancePhase() {
+        let haptic = HapticCounter()
+        let vm = ScannerViewModel(hapticFeedback: haptic.fire)
+
+        vm.qrDetected("UNASSIGNED")
+
+        XCTAssertEqual(vm.phase, .scanning,
+                       "Reserved-name QR must leave the phase at .scanning so the user can scan a real bin")
+        XCTAssertNil(vm.scannedBinId,
+                     "scannedBinId must remain nil — the scan HUD reads this directly")
+        XCTAssertEqual(vm.scanError, "This QR encodes a reserved bin name and was ignored.",
+                       "Friendly inline error must explain why the QR was rejected")
+        XCTAssertEqual(haptic.count, 0,
+                       "Haptic confirms a *successful* scan; it must NOT fire on a reserved-name reject")
+    }
+
+    func testReservedBinNameRejectionIsCaseAndWhitespaceInsensitive() {
+        sut.qrDetected("  binless  ")
+
+        XCTAssertEqual(sut.phase, .scanning)
+        XCTAssertNil(sut.scannedBinId)
+        XCTAssertNotNil(sut.scanError)
+    }
+
+    /// After a reserved-name reject, the user can still scan a normal bin —
+    /// state is recoverable, not latched.
+    func testRecoveryAfterReservedNameReject() {
+        sut.qrDetected("UNASSIGNED")
+        XCTAssertEqual(sut.phase, .scanning)
+
+        sut.qrDetected("BIN-0001")
+
+        XCTAssertEqual(sut.phase, .awaitingPhoto)
+        XCTAssertEqual(sut.scannedBinId, "BIN-0001")
+        XCTAssertNil(sut.scanError, "scanError must clear on the next successful scan")
+    }
 }


### PR DESCRIPTION
## Summary

Adds an iOS pre-flight guard for bin names the server reserves for its own sentinels. Closes QA PR #27 observation O-1 — the scan HUD at `BinsListView:184` reads `scannedBinId` directly, so a QR encoding `UNASSIGNED` previously flashed the raw token to the user before any other check ran.

Server-authoritative reject lands in parallel as ApiDev_011 (`reserved_bin_name`, HTTP 400). iOS mirrors the casefolded set so users don't need a round-trip for a guaranteed-failure name, and falls back to remap-the-server-message if the pre-flight ever misses.

## Three pieces

### 1. `Bin Brain/Models/BinNameValidator.swift` (new file)

Pure helper:
- `static let reservedNames: Set<String> = ["unassigned", "binless"]` — explicitly documented as needing to stay in sync with the server.
- `static func isReserved(_:) -> Bool` — trims whitespace and lowercases before set lookup.
- `static func friendlyMessage(for:) -> String` — single source of truth for the user-facing copy used by both pre-flight and server-reject mapping.

### 2. `ScannerViewModel.qrDetected` — pre-flight reject

After the existing `binIdPattern` regex check (which already rejects URL-injection payloads but lets `UNASSIGNED` through because it's alphanumeric), the validator gate fires:

```swift
guard !BinNameValidator.isReserved(trimmed) else {
    scanError = "This QR encodes a reserved bin name and was ignored."
    return
}
```

Phase stays `.scanning`, `scannedBinId` stays nil, no haptic — the scan HUD never sees the raw token. **Closes QA O-1.**

### 3. `AnalysisViewModel.ingestWithSessionRecovery` — server-reject mapping

If the server still returns `reserved_bin_name` (pre-flight somehow missed, or a future code path bypasses the scanner), remap the error message to `BinNameValidator.friendlyMessage(for: binId)` so the user sees one consistent explanation regardless of which validator caught it. Pure defensive — not expected to fire.

## A note on Step 2 of the prompt

The prompt's Step 2 asks for a "create-bin form pre-flight." There is **no** `POST /bins` direct create endpoint in this iOS client — bins are created server-side implicitly during `/ingest` (the multipart photo upload includes `bin_id`). The QR-scan flow is the de facto create entrypoint, so prompt Step 3 (QR pre-flight) and Step 4 (server-reject mapping) together satisfy the original intent.

## Tests

`BinNameValidatorTests` (new file, **7 cases**):
- Truthy: `UNASSIGNED`, `unassigned`, `Unassigned`, `uNaSsIgNeD`, `Binless`, `BINLESS`, `binless`, `  UNASSIGNED  `, `Binless\n`, `\tunassigned\t`.
- Falsy: `kitchen`, `BIN-0001`, `garage-shelf-A`, `""`, `" "`, `"\n\t"`, `unassigned-tools`, `my binless bin` (substring containment must NOT match).
- `friendlyMessage(for:)` quotes the trimmed input and contains "reserved".

`ScannerViewModelTests` (**+3 cases**):
- Reserved-name QR leaves `phase=.scanning`, `scannedBinId=nil`, sets the friendly `scanError`, and does **not** fire the haptic (haptic is success-only).
- Case + whitespace insensitivity through the scanner path (`  binless  `).
- Recovery: a reserved-name reject doesn't latch — the next valid scan succeeds and `scanError` clears.

**Full unit suite: 535/535 green (was 525, +10 new), zero new warnings.**

## Coordination

- Server reject (ApiDev_011) is authoritative; iOS mirrors the set. **If a new reserved name is added server-side, mirror it in `BinNameValidator.reservedNames`** — call out in the PR description if you ever bump it.
- No DB writes, no prod side effects — pure client code.

## Prompt / size

- Prompt: `binbrain/.swarm/Prompts/Swift2_023_reserved_bin_names.md`
- Reports: `binbrain/.swarm/AssessmentReports/QA_iOS_PR27_041926.md` observation O-1 (closed by this PR)
- Diff: +176 / -0 (66 prod + 110 test LOC) — well under the <100 prod + <200 test budget.

## Reviewer instructions

Standard cadence: aegis SEC + QA in parallel, Architect waits for **both** before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent creation of bins with reserved names ("unassigned," "binless").
  * Improved error messaging when reserved names are attempted, providing clear user guidance.
  * Extended reserved-name detection to QR code scans, preventing reserved names from being processed.

* **Tests**
  * Added comprehensive unit tests for reserved-name validation logic.
  * Added tests for QR scanner behavior with reserved names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->