### PR TITLE
Session recovery polish: G-2 tighten + G-3/G-4 + SEC docstrings + retry header (Swift2_019c)

### DIFF
--- a/Bin Brain/Bin Brain/Services/APIClient.swift
+++ b/Bin Brain/Bin Brain/Services/APIClient.swift
@@ -263,11 +263,18 @@ final class APIClient {
     ///   - sessionId: Optional server-minted session UUID (`Swift2_019`).
     ///     Sent as a `session_id` multipart field. Server PR #35 rejects
     ///     any non-UUID value with 400 `invalid_session`.
+    ///   - retryCount: Defaults to 0 (first attempt). When > 0, stamps
+    ///     `X-Client-Retry-Count: <n>` on the request so server-side
+    ///     telemetry can correlate "this ingest is a session-recovery
+    ///     retry" vs an independent first attempt. Mirrors the pattern
+    ///     PR #23 set for `/outcomes`. Observational only — server has
+    ///     no behavior conditioned on the value (Swift2_019c / SEC-25-4).
     func ingest(
         jpegData: Data,
         binId: String,
         deviceMetadata: String? = nil,
-        sessionId: UUID? = nil
+        sessionId: UUID? = nil,
+        retryCount: Int = 0
     ) async throws -> IngestResponse {
         var fields = ["bin_id": binId]
         if let deviceMetadata {
@@ -282,12 +289,17 @@ final class APIClient {
             fileName: "photo.jpg",
             mimeType: "image/jpeg"
         )
+        var extraHeaders: [String: String] = [:]
+        if retryCount > 0 {
+            extraHeaders["X-Client-Retry-Count"] = "\(retryCount)"
+        }
         return try await request(
             path: "/ingest",
             method: "POST",
             body: body,
             contentType: "multipart/form-data; boundary=\(boundary)",
-            timeout: 30
+            timeout: 30,
+            extraHeaders: extraHeaders
         )
     }
 
@@ -805,7 +817,8 @@ final class APIClient {
         contentType: String?,
         timeout: TimeInterval,
         requiresAuth: Bool = true,
-        probeWithCurrentKey: Bool = false
+        probeWithCurrentKey: Bool = false,
+        extraHeaders: [String: String] = [:]
     ) async throws -> T {
         if requiresAuth {
             guard hasAPIKey else {
@@ -829,6 +842,9 @@ final class APIClient {
         }
         if let apiKey, shouldAttachKey(requiresAuth: requiresAuth, probe: probeWithCurrentKey) {
             urlRequest.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
+        for (name, value) in extraHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: name)
         }
 
         let bodySize = body.map { "\($0.count) bytes" } ?? "none"

--- a/Bin Brain/Bin Brain/Services/SessionManager.swift
+++ b/Bin Brain/Bin Brain/Services/SessionManager.swift
@@ -51,6 +51,16 @@ final class SessionManager {
     /// Main-actor isolation guarantees the `beginTask = task` assignment
     /// and the first-reader `if let beginTask` check serialize correctly
     /// — no lock needed.
+    ///
+    /// Swift2_019c / SEC-25-1 — the in-flight Task closes over the *first*
+    /// caller's `apiClient`. All concurrent `activeSessionId` callers
+    /// today MUST share one `APIClient` instance (same api-key /
+    /// base-URL); BinsListView, BinDetailView, and SettingsView all use
+    /// the `@Environment`-injected client, so this holds. If the app ever
+    /// grows a per-feature `APIClient` (e.g. a background uploader with
+    /// a different keychain), this memoization will silently cross-wire
+    /// session ownership — that's the rebuild trigger, not a bug to fix
+    /// pre-emptively.
     private var beginTask: Task<Session, Error>?
 
     // MARK: - Init

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -479,6 +479,11 @@ final class AnalysisViewModel {
                 )
             )
         } catch let apiError as APIError where apiError.error.code == "invalid_session" {
+            // Swift2_019c / SEC-25-5 — intentionally tight-keyed to
+            // `invalid_session` only. Adjacent codes (`session_expired`,
+            // `session_closed`, `session_owner_mismatch`) are NOT caught
+            // by design; any server-side addition to the recovery-eligible
+            // set requires a matched iOS release that updates this clause.
             // Server invalidated our cached session. Drop it locally, get
             // a fresh one, and retry exactly once. If sessionManager is
             // nil (legacy callers without session wiring), the original
@@ -491,11 +496,15 @@ final class AnalysisViewModel {
             logger.info("[SESSION] server returned invalid_session for \(sessionId?.uuidString ?? "nil", privacy: .private) — invalidating and retrying with fresh session")
             sessionManager.invalidateCurrentSession(ifCurrentIs: sessionId)
             let freshId = try await sessionManager.activeSessionId(apiClient: apiClient)
+            // Swift2_019c / SEC-25-4 — stamp the retry so server-side
+            // telemetry can distinguish a session-recovery retry from an
+            // independent first attempt. Mirrors the /outcomes pattern.
             return try await apiClient.ingest(
                 jpegData: jpegData,
                 binId: binId,
                 deviceMetadata: deviceMetadata,
-                sessionId: freshId
+                sessionId: freshId,
+                retryCount: 1
             )
         }
     }

--- a/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
+++ b/Bin Brain/Bin BrainTests/AnalysisViewModelSessionRecoveryTests.swift
@@ -143,6 +143,9 @@ final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
 
         // Phase 2 — install the scenario handler AFTER the seed completes.
         var ingestCount = 0
+        var firstAttemptRetryHeader: String?
+        var retryAttemptRetryHeader: String?
+        var retrySessionField: String?
         let client = makeClient { [self] request in
             let path = request.url?.path ?? ""
             if request.httpMethod == "POST", path == "/sessions" {
@@ -151,7 +154,16 @@ final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
             if path == "/ingest" {
                 ingestCount += 1
                 if ingestCount == 1 {
+                    firstAttemptRetryHeader = request.value(forHTTPHeaderField: "X-Client-Retry-Count")
                     return (response(400, for: request), invalidSessionErrorJSON)
+                }
+                retryAttemptRetryHeader = request.value(forHTTPHeaderField: "X-Client-Retry-Count")
+                if let body = request.bodyData,
+                   let s = String(data: body, encoding: .utf8) {
+                    // Multipart field; substring match is fine since the
+                    // body was constructed by our own APIClient.
+                    retrySessionField = s.components(separatedBy: "session_id\"\r\n\r\n")
+                        .dropFirst().first?.prefix(36).description
                 }
                 return (response(200, for: request), ingestSuccessJSON)
             }
@@ -177,6 +189,24 @@ final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
                        "Retry must use the freshly-minted session, not the stale one")
         XCTAssertEqual(sut.phase, .complete,
                        "After successful retry, phase must land on .complete")
+
+        // Swift2_019c G-2 / SEC-25-3 — assert the retry body actually
+        // carries freshId, not staleId. Activates the previously-unused
+        // bodyData helper. A typo regression like `sessionId: staleId`
+        // would leave this assertion failing even though the mock-200
+        // round-trip would otherwise pass.
+        XCTAssertEqual(retrySessionField, freshId.uuidString.lowercased(),
+                       "Retry /ingest must carry the freshly-minted session_id, not the stale one")
+        XCTAssertNotEqual(retrySessionField, staleId.uuidString.lowercased(),
+                          "Retry /ingest must NOT reuse the stale session_id")
+
+        // Swift2_019c SEC-25-4 — header is observational only but the
+        // first attempt MUST NOT carry it (so server telemetry can
+        // distinguish "user's first try" from "client-driven recovery").
+        XCTAssertNil(firstAttemptRetryHeader,
+                     "X-Client-Retry-Count must be absent on the first attempt")
+        XCTAssertEqual(retryAttemptRetryHeader, "1",
+                       "X-Client-Retry-Count: 1 must be stamped on the recovery retry")
     }
 
     /// Swift2_019b G-1 (PR #25 QA). A delayed `invalid_session` 400 for
@@ -278,6 +308,109 @@ final class AnalysisViewModelSessionRecoveryTests: XCTestCase {
         } else {
             XCTFail("Retry failure must surface as .failed, got \(sut.phase)")
         }
+    }
+
+    // MARK: - Swift2_019c G-3 — retry-also-invalid_session must not loop
+
+    /// Pin the single-retry bound when the retry itself also returns
+    /// 400 `invalid_session`. The catch clause is not re-entrant, but a
+    /// future regression that wrapped the retry in another do/catch could
+    /// re-enter the recovery branch — this test would catch it.
+    func testRunInvalidSessionRetryAlsoInvalidSessionDoesNotLoop() async throws {
+        let staleId = UUID()
+        let freshId = UUID()
+
+        let seedClient = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                return (response(201, for: request), sessionJSON(staleId))
+            }
+            return (response(500, for: request), Data())
+        }
+        _ = try await sessionManager.beginSession(apiClient: seedClient)
+
+        var ingestCount = 0
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON(freshId))
+            }
+            if path == "/ingest" {
+                ingestCount += 1
+                return (response(400, for: request), invalidSessionErrorJSON)
+            }
+            return (response(500, for: request), Data())
+        }
+
+        await sut.run(
+            jpegData: Data("fake".utf8),
+            binId: "BIN-0001",
+            apiClient: client,
+            sessionId: staleId,
+            sessionManager: sessionManager
+        )
+
+        XCTAssertEqual(ingestCount, 2,
+                       "Single-retry bound must hold even when the retry itself is also invalid_session")
+        if case .failed = sut.phase { /* ok */ } else {
+            XCTFail("Retry-with-same-error must surface as .failed, got \(sut.phase)")
+        }
+    }
+
+    // MARK: - Swift2_019c G-4 — overrideQualityGate recovery path
+
+    /// Near-clone of testRunInvalidSessionResponse... but driving through
+    /// `overrideQualityGate(...)` instead of `run(...)`. The recovery
+    /// helper is shared/static, but the wiring from `overrideQualityGate`
+    /// is independent of `run` and can regress on its own.
+    func testOverrideQualityGateInvalidSessionResponseInvalidatesAndRetriesOnce() async throws {
+        let staleId = UUID()
+        let freshId = UUID()
+
+        // Phase 1 — seed the SessionManager with a stale session.
+        sessionManager = SessionManager()
+        let seedClient = makeClient { [self] request in
+            if request.httpMethod == "POST", request.url?.path == "/sessions" {
+                return (response(201, for: request), sessionJSON(staleId))
+            }
+            return (response(500, for: request), Data())
+        }
+        _ = try await sessionManager.beginSession(apiClient: seedClient)
+        XCTAssertEqual(sessionManager.current?.id, staleId, "precondition: stale session cached")
+
+        // Phase 2 — install scenario handler.
+        var ingestCount = 0
+        let client = makeClient { [self] request in
+            let path = request.url?.path ?? ""
+            if request.httpMethod == "POST", path == "/sessions" {
+                return (response(201, for: request), sessionJSON(freshId))
+            }
+            if path == "/ingest" {
+                ingestCount += 1
+                if ingestCount == 1 {
+                    return (response(400, for: request), invalidSessionErrorJSON)
+                }
+                return (response(200, for: request), ingestSuccessJSON)
+            }
+            if path.hasSuffix("/suggest") {
+                return (response(200, for: request), suggestSuccessJSON)
+            }
+            return (response(500, for: request), Data())
+        }
+
+        await sut.overrideQualityGate(
+            jpegData: Data("fake-jpeg".utf8),
+            binId: "BIN-0001",
+            apiClient: client,
+            sessionId: staleId,
+            sessionManager: sessionManager
+        )
+
+        XCTAssertEqual(ingestCount, 2,
+                       "overrideQualityGate must also retry /ingest exactly once after invalid_session")
+        XCTAssertEqual(sessionManager.current?.id, freshId,
+                       "Override path must use the freshly-minted session, not the stale one")
+        XCTAssertEqual(sut.phase, .complete,
+                       "After successful retry via override path, phase must land on .complete")
     }
 }
 


### PR DESCRIPTION
# Swift2_019c — Session recovery polish bundle

Closes the 6 deferred items from PR #25's QA + SEC reviews. All low-risk; no behavior changes to the recovery path itself.

## Bundle contents

| Item | Where | What |
|------|-------|------|
| **G-2** + **SEC-25-3** | `AnalysisViewModelSessionRecoveryTests.swift` | Tighten existing recovery test to capture the retry's multipart body via the previously-unused `URLRequest.bodyData` helper. Asserts retry body carries `freshId.uuidString.lowercased()`, NOT `staleId`. SEC-25-3 closes "for free" — the helper is now load-bearing. |
| **G-3** | same file | New `testRunInvalidSessionRetryAlsoInvalidSessionDoesNotLoop` — pins the single-retry bound when the retry itself ALSO returns `invalid_session`. Asserts `ingestCount == 2`, `phase == .failed`. |
| **G-4** | same file | New `testOverrideQualityGateInvalidSessionResponseInvalidatesAndRetriesOnce` — independent coverage for the `overrideQualityGate(...)` wiring into the shared recovery helper. The helper is shared, but the wiring is not, and could regress on its own. |
| **SEC-25-1** | `SessionManager.swift` | Docstring on `beginTask` recording the apiClient-closure invariant: all concurrent `activeSessionId` callers MUST share one `APIClient`. Per-feature client growth is the rebuild trigger for the memoization, not a bug to fix pre-emptively. |
| **SEC-25-4** | `APIClient.swift` + `AnalysisViewModel.swift` | Added optional `retryCount: Int = 0` parameter to `APIClient.ingest(...)`. When `> 0`, stamps `X-Client-Retry-Count: <n>` on the request via the new `extraHeaders:` plumbing on the private `request<T>` helper. Recovery helper passes `retryCount: 1` on the retry only. Mirrors the pattern PR #23 set for `/outcomes`. Observational only — no server behavior conditioned on the value. The G-2 assertion was extended to verify the header is **absent on the first attempt** and `"1"` on the retry. |
| **SEC-25-5** | `AnalysisViewModel.swift` | Docstring on the `catch let apiError as APIError where ... == "invalid_session"` clause noting the intentional tight keying. Adjacent codes (`session_expired`, `session_closed`, `session_owner_mismatch`) are NOT caught by design; server-side additions require a matched iOS release. No behavior change. |

## Tests

- Full `Bin BrainTests` target: **537/537 green**, 0 failures (run on iPhone 17 sim).
- Recovery suite: **5/5 green** — 3 pre-existing + 2 new (G-3, G-4) + 1 tightened (G-2).
- Unit-test target time: ~52 s (parallel sim clones).

## Size

| Bucket | Budget | Actual | Notes |
|--------|--------|--------|-------|
| Production LOC | < 50 | **43** | APIClient (+22), SessionManager (+10), AnalysisViewModel (+11) |
| Test LOC | < 100 | **133** | G-2 tighten (+38, includes the SEC-25-4 header assertions bundled in), G-3 (+45), G-4 (+50). Over budget by ~33%, but this is cohesive added test coverage in a single file — splitting into a separate PR would be procedural churn. Flagging explicitly per the prompt. |

## Commits (logical chunks per prompt)

1. `d26f760` — docs(session): SEC-25-1 docstring (SessionManager only)
2. `c4bc070` — feat(ingest): SEC-25-4 header + SEC-25-5 docstring (APIClient + AnalysisViewModel)
3. `91d14ab` — test(session-recovery): G-2 tighten + G-3 + G-4 (single test file)

## Explicitly NOT in scope

- Broadening the catch clause (SEC-25-5 is docstring-only).
- G-6 — resolved for free by PR #25's G-1 `ifCurrentIs:` fix.
- Production retry-count > 1 behavior — header is observational only.

## Reference

- Prompt: `binbrain/.swarm/Prompts/Swift2_019c_session_recovery_polish.md`
- QA report: `binbrain/.swarm/AssessmentReports/QA_iOS_PR25_041926.md`
- SEC report: `binbrain/.swarm/AssessmentReports/SEC_iOS_PR25_041926.md`
