### PR TITLE
Surface duplicate-association as info toast (Swift2_029)

### DIFF
--- a/Bin Brain/Bin Brain/Models/APIModels.swift
+++ b/Bin Brain/Bin Brain/Models/APIModels.swift
@@ -291,15 +291,38 @@ struct UpsertItemResponse: Decodable {
 }
 
 /// The response returned by `POST /associate` (link an item to a bin).
+///
+/// Server PR #41 (ApiDev2_013) added `inserted: bool` so the client can
+/// distinguish a brand-new association from an idempotent no-op (the
+/// `(bin_id, item_id)` row already existed and the server explicitly
+/// did NOT merge quantity/confidence). When `inserted == false`, the
+/// user's edited quantity was discarded by the server — the toast in
+/// `SuggestionReviewViewModel.confirm()` surfaces this for the user.
+///
+/// Backward-compat: a missing `inserted` key (pre-PR-#41 server, or
+/// staging drift) decodes as `inserted = true` so the old contract
+/// ("association succeeded; nothing to surface") survives unchanged.
 struct AssociateItemResponse: Decodable {
     let ok: Bool
     let binId: String
     let itemId: Int
+    let inserted: Bool
 
     enum CodingKeys: String, CodingKey {
         case ok
         case binId = "bin_id"
         case itemId = "item_id"
+        case inserted
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.ok = try c.decode(Bool.self, forKey: .ok)
+        self.binId = try c.decode(String.self, forKey: .binId)
+        self.itemId = try c.decode(Int.self, forKey: .itemId)
+        // Swift2_029: default to true for graceful degradation against
+        // any server that hasn't shipped PR #41 yet.
+        self.inserted = try c.decodeIfPresent(Bool.self, forKey: .inserted) ?? true
     }
 }
 

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -137,6 +137,21 @@ final class SuggestionReviewViewModel {
     /// partial-failure summary. Never silently swallowed. (Swift2_013)
     var confirmationErrorMessage: String?
 
+    /// User-facing **informational** post-confirm message — distinct from
+    /// `confirmationErrorMessage` so that "this worked, here's some
+    /// context" copy doesn't ride on the error channel. Currently only set
+    /// by the duplicate-association toast (Swift2_029): when the server
+    /// returns `inserted:false` on one or more `/associate` responses, the
+    /// `(bin_id, item_id)` row already existed and the user's edited
+    /// quantity was NOT applied. The view observes this with `onChange`
+    /// and surfaces it via the same toast environment as the error field.
+    var confirmationInfoMessage: String?
+
+    /// Count of `/associate` responses in the most recent `confirm()` that
+    /// returned `inserted:false`. Reset at the top of every `confirm()`.
+    /// Drives `confirmationInfoMessage` after the loop completes.
+    private(set) var duplicateAssociationCount: Int = 0
+
     /// Snapshot of the on-device top-K classifications captured at
     /// `loadPreliminaryClassifications(_:topK:)` time. Used by the `#if DEBUG`
     /// logger in `confirm(...)` to emit (top-K vs. confirmed label) pairs.
@@ -382,7 +397,9 @@ final class SuggestionReviewViewModel {
         isConfirming = true
         failedIndices = []
         teachFailureCount = 0
+        duplicateAssociationCount = 0
         confirmationErrorMessage = nil
+        confirmationInfoMessage = nil
         let includedIndices = editableSuggestions.indices.filter { editableSuggestions[$0].included }
         logger.debug("confirm: \(self.editableSuggestions.count, privacy: .public) total, \(includedIndices.count, privacy: .public) included")
         for idx in includedIndices {
@@ -400,12 +417,19 @@ final class SuggestionReviewViewModel {
                     confidence: confidence,
                     binId: binId
                 )
-                _ = try await apiClient.associateItem(
+                let associateResponse = try await apiClient.associateItem(
                     binId: binId,
                     itemId: upsert.itemId,
                     confidence: confidence,
                     quantity: quantity
                 )
+                // Swift2_029 — server PR #41 reports inserted:false when
+                // the (bin, item) row pre-existed and quantity/confidence
+                // were intentionally NOT merged. Count for the post-loop
+                // info toast so the user knows their edit was discarded.
+                if !associateResponse.inserted {
+                    duplicateAssociationCount += 1
+                }
             } catch {
                 let remaining = includedIndices.filter { $0 >= idx }
                 failedIndices = remaining
@@ -450,6 +474,15 @@ final class SuggestionReviewViewModel {
                 logger.error("confirmClass failed for '\(s.editedName, privacy: .private)': \(error.localizedDescription, privacy: .private)")
                 teachFailureCount += 1
             }
+        }
+
+        // Swift2_029 — surface the duplicate-association count as an info
+        // toast. Server explicitly did NOT merge quantity/confidence on
+        // the pre-existing rows; this tells the user "your edit was
+        // discarded" so a silent server no-op stops being silent.
+        if duplicateAssociationCount > 0 {
+            confirmationInfoMessage =
+                "\(duplicateAssociationCount) of \(includedIndices.count) items were already in this bin — their quantities were not changed."
         }
 
         // Swift2_014 — telemetry fires only on confirm-success; failures here

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -100,6 +100,16 @@ struct SuggestionReviewView: View {
             toast.show(message, duration: 4.0)
             viewModel.confirmationErrorMessage = nil
         }
+        .onChange(of: viewModel.confirmationInfoMessage) { _, newValue in
+            // Swift2_029 — informational post-confirm copy (currently the
+            // duplicate-association notice). Same toast channel, same
+            // clear-after-show pattern as the error field; kept on a
+            // distinct VM property so future info copy doesn't ride on
+            // the error channel.
+            guard let message = newValue else { return }
+            toast.show(message, duration: 4.0)
+            viewModel.confirmationInfoMessage = nil
+        }
     }
 
     // MARK: - Pinned Photo with Bbox Overlay

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
@@ -1208,4 +1208,121 @@ final class SuggestionReviewViewModelTests: XCTestCase {
                      "successful confirm must not leave a stale error message")
         XCTAssertTrue(sut.failedIndices.isEmpty, "no failures expected on happy path")
     }
+
+    // MARK: - Swift2_029 — duplicate-association feedback toast
+
+    /// Server PR #41 shape: every `/associate` returns `inserted:true`.
+    /// Asserts the regression — when nothing is a duplicate, no info
+    /// toast fires and the duplicate counter stays at zero.
+    private var associateInsertedTrueJSON: Data {
+        Data("""
+        {"ok":true,"bin_id":"BIN-0001","item_id":101,"inserted":true}
+        """.utf8)
+    }
+
+    /// Server PR #41 shape for an already-existing `(bin, item)` row.
+    /// `inserted:false` means the server did NOT merge quantity/confidence.
+    private var associateInsertedFalseJSON: Data {
+        Data("""
+        {"ok":true,"bin_id":"BIN-0001","item_id":101,"inserted":false}
+        """.utf8)
+    }
+
+    /// Two suggestions, both /associate responses inserted:true. No
+    /// duplicate-info toast must fire and the counter must remain zero.
+    /// Pins the existing-behavior contract under the new field.
+    func testConfirmAllInsertedTrueLeavesInfoMessageNil() async throws {
+        let suggestions = try makeSuggestions()
+        sut.loadSuggestions(suggestions)
+
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateInsertedTrueJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+
+        XCTAssertEqual(sut.duplicateAssociationCount, 0,
+                       "all inserted:true responses must leave duplicate count at zero")
+        XCTAssertNil(sut.confirmationInfoMessage,
+                     "no info toast should fire when nothing is a duplicate")
+        XCTAssertNil(sut.confirmationErrorMessage,
+                     "happy path must not set the error message either")
+    }
+
+    /// Two suggestions: first inserted:true, second inserted:false. The
+    /// duplicate-info toast must surface "1 of 2" in the copy so the user
+    /// sees that one of their edited quantities was discarded.
+    func testConfirmInsertedFalseSurfacesDuplicateInfoToast() async throws {
+        let suggestions = try makeSuggestions()
+        sut.loadSuggestions(suggestions)
+
+        var associateCount = 0
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                associateCount += 1
+                let body = associateCount == 1
+                    ? associateInsertedTrueJSON
+                    : associateInsertedFalseJSON
+                return (mockResponse(statusCode: 200, for: request), body)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+
+        XCTAssertEqual(sut.duplicateAssociationCount, 1,
+                       "exactly one inserted:false must increment the counter once")
+        let message = try XCTUnwrap(sut.confirmationInfoMessage,
+                                    "an inserted:false response must publish an info toast")
+        // Substring assertion — copy may evolve. Exact-string match would
+        // make this brittle for a UX-text change.
+        XCTAssertTrue(message.contains("1 of 2"),
+                      "info toast must read 'N of M' with N=1, M=2 — got: \(message)")
+        XCTAssertNil(sut.confirmationErrorMessage,
+                     "duplicate-no-op is informational, not an error")
+        XCTAssertTrue(sut.failedIndices.isEmpty,
+                      "duplicate-no-op must not be classified as a failure")
+    }
+
+    /// Backward-compat: a pre-PR-#41 server omits the `inserted` key. The
+    /// decoder must fall back to `inserted = true` so the old
+    /// "association succeeded; nothing to surface" contract still holds.
+    /// Reuses the historic `associateSuccessJSON` fixture (no `inserted`
+    /// key) — the absence is the test.
+    func testConfirmTreatsMissingInsertedKeyAsTrue() async throws {
+        let suggestions = try makeSuggestions()
+        sut.loadSuggestions(suggestions)
+
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path.contains("/classes/confirm") {
+                return (mockResponse(statusCode: 200, for: request), confirmClassSuccessJSON)
+            }
+            if path.hasSuffix("/associate") {
+                // Omits "inserted" entirely — mirrors a pre-PR-#41 server.
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+
+        XCTAssertEqual(sut.duplicateAssociationCount, 0,
+                       "absent inserted key must default to true (no false-positive duplicates)")
+        XCTAssertNil(sut.confirmationInfoMessage,
+                     "back-compat path must not surface a duplicate toast")
+        XCTAssertNil(sut.confirmationErrorMessage,
+                     "back-compat decode must not surface an error either")
+    }
 }


### PR DESCRIPTION
# Swift2_029 — Surface `/associate` `inserted:false` as info toast

Surfaces the new `inserted` field from server PR #41 (ApiDev2_013, deployed at `99be22f`) as a post-confirm informational toast so users know when their edited quantity was discarded by the server's idempotent no-merge.

## What changes

| Layer | Change |
|------|--------|
| `Models/APIModels.swift` | `AssociateItemResponse` gains `inserted: Bool`. Custom `init(from:)` defaults to `true` when the key is absent — graceful degradation against any pre-PR-#41 server (or staging drift). |
| `ViewModels/SuggestionReviewViewModel.swift` | Two new properties: `confirmationInfoMessage: String?` (distinct channel from `confirmationErrorMessage`) and `duplicateAssociationCount: Int`. `confirm()` resets both at the top, increments the count when `response.inserted == false`, and publishes "N of M items were already in this bin — their quantities were not changed." after the loop completes. |
| `Views/Cataloging/SuggestionReviewView.swift` | New `onChange(of: viewModel.confirmationInfoMessage)` mirrors the existing error-message handler — same toast environment, same clear-after-show pattern. |
| `Tests/SuggestionReviewViewModelTests.swift` | Three new tests (see below). |

### Decision: split `confirmationInfoMessage` from `confirmationErrorMessage`

The prompt asked SwiftDev to weigh "reuse error field" vs "split into info field". Split chosen because the budget had room (~10 LOC for the second `onChange` + property), and routing post-confirm informational copy through a field literally named `confirmationErrorMessage` is a semantic smell that future contributors would have to puzzle over. The `Toast` environment doesn't differentiate by severity, so both fields ride the same UI surface — this is purely a VM-level naming concern.

## Tests

3 new cases in `SuggestionReviewViewModelTests.swift`:

| Test | Asserts |
|------|--------|
| `testConfirmAllInsertedTrueLeavesInfoMessageNil` | All `inserted:true` ⇒ `duplicateAssociationCount == 0`, `confirmationInfoMessage == nil`. Pins the existing-behavior regression contract. |
| `testConfirmInsertedFalseSurfacesDuplicateInfoToast` | First `inserted:true`, second `inserted:false` ⇒ `duplicateAssociationCount == 1`, info message contains substring `"1 of 2"`, error message stays nil, no failure recorded. Substring match keeps the test from being brittle to copy edits. |
| `testConfirmTreatsMissingInsertedKeyAsTrue` | Reuses the historic `associateSuccessJSON` fixture (no `inserted` key) — the absence is the test. Asserts no false-positive duplicates from a server that hasn't shipped PR #41. |

Full `Bin BrainTests` target: **green** on iPhone 17 sim. Recovery suite + the 3 new cases all pass.

## Size

| Bucket | Budget | Actual | Notes |
|--------|--------|--------|-------|
| Production LOC | < 80 | **68** | APIModels (+23), SuggestionReviewViewModel (+34), SuggestionReviewView (+10) |
| Test LOC | < 150 | **117** | Three tests + two fixture properties |

Both within budget; no scope creep, no premature abstractions.

## NOT in scope (per prompt)

- No retry on `inserted:false` (server explicitly decided no merging).
- No client-side quantity merge or override.
- No changes to `upsertItem` handling.
- No analytics/telemetry hook — purely UX.

## Commits

1. `e423542` — feat: AssociateItemResponse decode + VM duplicate counter + view onChange wire
2. `34d1178` — test: 3 new cases (happy / duplicate / back-compat)

## Reference

- Prompt: `binbrain/.swarm/Prompts/Swift2_029_surface_already_in_bin_toast.md`
- Server PR #41 / ApiDev2_013 (deployed `99be22f`)
