### PR TITLE
Outcomes queue polish: CAS comment + reclaim cap + on-disk round-trip + retry-key + delivered-TTL doc (Swift2_018c)

### DIFF
--- a/Bin Brain/Bin Brain/Models/PendingOutcome.swift
+++ b/Bin Brain/Bin Brain/Models/PendingOutcome.swift
@@ -23,7 +23,10 @@ enum OutcomeQueueStatus: Int, Codable, Sendable {
     /// can re-queue stuck rows on relaunch.
     case sending = 1
     /// Server accepted the POST (2xx). Retained for Settings visibility
-    /// for 7 days, then swept like any other row past TTL.
+    /// for 7 days, then deleted (NOT marked `.expired`) by
+    /// `OutcomeQueueManager.expireAged` — delivered rows have no further
+    /// use once aged out, so the cleaner contract is removal. (Swift2_018c
+    /// F-4 doc fix; behavior was already in place from PR #26.)
     case delivered = 2
     /// Permanent failure — either a non-retryable 4xx, 20 retry attempts
     /// exhausted, or age > 7 days. Surfaced in Settings "Pending Outcomes"

--- a/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
+++ b/Bin Brain/Bin Brain/Services/OutcomeQueueManager.swift
@@ -48,11 +48,35 @@ final class OutcomeQueueManager {
     /// TTL beyond which a row is expired regardless of status. 7 days.
     static let maxAge: TimeInterval = 7 * 24 * 60 * 60
 
+    /// Swift2_018c / SEC-26-2 — upper bound on rows reclaimed in a single
+    /// `reclaimOrphanedSendingRows()` call. If a crash-loop somehow
+    /// produced thousands of orphaned `.sending` rows, an unbounded
+    /// reclaim would re-fire every one of them through the network at
+    /// launch — turning a one-shot recovery into a denial of service
+    /// against the user's own server. 100 rows is enough to recover
+    /// from any plausible burst of in-flight outcomes (cataloging
+    /// produces << 100 outcomes/min); the rest wait for the next launch
+    /// (bounded forward progress).
+    static let maxReclaimPerLaunch: Int = 100
+
     // MARK: - Observable counts (for Settings)
 
     private(set) var pendingCount: Int = 0
     private(set) var deliveredCount: Int = 0
     private(set) var expiredCount: Int = 0
+
+    /// Swift2_018c / SEC-26-2 — true when the most recent
+    /// `reclaimOrphanedSendingRows()` call hit `maxReclaimPerLaunch`
+    /// and stopped early. Tested in `OutcomeQueueManagerTests` and
+    /// surfaced as a `logger.warning` in production. Reset to `false`
+    /// at the top of every reclaim call.
+    private(set) var lastReclaimCapHit: Bool = false
+
+    /// Swift2_018c / SEC-26-2 — number of `.sending` rows actually
+    /// flipped to `.pending` by the most recent
+    /// `reclaimOrphanedSendingRows()` call. Capped at
+    /// `maxReclaimPerLaunch`. Useful for tests and (future) telemetry.
+    private(set) var lastReclaimCount: Int = 0
 
     // MARK: - Test seams
 
@@ -202,6 +226,8 @@ final class OutcomeQueueManager {
     /// `retryCount` on reclaim: callers can distinguish "crashed mid
     /// first attempt" from "retried normally" via the count.
     func reclaimOrphanedSendingRows(context: ModelContext) {
+        lastReclaimCapHit = false
+        lastReclaimCount = 0
         let all: [PendingOutcome]
         do {
             all = try context.fetch(FetchDescriptor<PendingOutcome>())
@@ -209,12 +235,22 @@ final class OutcomeQueueManager {
             logger.error("[OUTCOMES] reclaim fetch failed: \(error.localizedDescription, privacy: .private)")
             return
         }
-        var touched = false
+        var reclaimed = 0
         for row in all where row.status == .sending {
+            // Swift2_018c / SEC-26-2 — bounded reclaim per launch.
+            // Stops a runaway crash-loop from re-firing every orphaned
+            // row through the network at relaunch. Remaining rows wait
+            // for the NEXT launch.
+            if reclaimed >= Self.maxReclaimPerLaunch {
+                lastReclaimCapHit = true
+                logger.warning("[OUTCOMES] reclaim cap hit — \(reclaimed, privacy: .public) rows reclaimed in one launch; possible crash loop")
+                break
+            }
             row.status = .pending
-            touched = true
+            reclaimed += 1
         }
-        if touched {
+        lastReclaimCount = reclaimed
+        if reclaimed > 0 {
             save(context)
             refreshCounts(context: context)
         }
@@ -314,13 +350,28 @@ final class OutcomeQueueManager {
         context: ModelContext,
         apiClient: APIClient
     ) async {
-        // Swift2_018b F-3 — CAS guard. Concurrent drain triggers
-        // (NWPathMonitor `.satisfied` + willEnterForeground +
-        // scenePhase `.active`) can schedule two `attemptDelivery`
-        // Tasks for the same row. Main-actor isolation guarantees the
-        // check-flip-save below runs to completion between awaits, so
-        // the second task on resumption sees `.sending` and returns
-        // early — only one POST fires.
+        // Swift2_018b F-3 / Swift2_018c G-1 + SEC-26-1 — CAS guard.
+        //
+        // Concurrent drain triggers (NWPathMonitor `.satisfied` +
+        // willEnterForeground + scenePhase `.active`) can schedule two
+        // `attemptDelivery` Tasks for the same row. The check-flip-save
+        // below relies on running to completion between awaits so the
+        // second Task sees `.sending` and returns early — only one POST
+        // fires.
+        //
+        // *De-facto* MainActor isolation, NOT annotation-enforced:
+        // `OutcomeQueueManager` is intentionally NOT `@MainActor` (the
+        // SwiftData `ModelContext` is a main-thread context but the
+        // class proper is non-isolated to keep `enqueue`/`drain`/
+        // `retryAll` callable from arbitrary contexts). Every production
+        // caller — `SuggestionReviewViewModel.fireOutcomesIfReady`,
+        // `runMonitoredDrain`, the scenePhase observer in `Bin_BrainApp`
+        // — routes through MainActor before invoking us, and that's
+        // what makes the CAS atomic in practice. If a future caller
+        // ever invokes `attemptDelivery` from a non-MainActor context,
+        // it MUST add explicit serialization (actor, lock, or
+        // MainActor.run wrapper) before the call, OR this guard must
+        // be hardened with a real CAS primitive.
         guard row.status == .pending else { return }
         row.status = .sending
         save(context)

--- a/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
+++ b/Bin Brain/Bin BrainTests/OutcomeQueueManagerTests.swift
@@ -501,10 +501,11 @@ final class OutcomeQueueManagerTests: XCTestCase {
                        "First POST must carry Idempotency-Key header equal to PendingOutcome.id")
     }
 
-    /// F-6 retry stability: the second attempt for a row must reuse the
-    /// original UUID so the server can collapse the duplicate. A fresh
-    /// UUID per attempt would make the key useless for dedup.
-    func testOutcomeRetryReusesSameIdempotencyKey() async throws {
+    /// F-6 retry stability — single-POST smoke test for the simple case
+    /// where one drain produces one POST. The cross-drain stability
+    /// contract (key identical across multiple POSTs for the same row)
+    /// is in `testOutcomeRetryKeyIsStableAcrossMultiplePosts` below.
+    func testOutcomePostHeaderEqualsRowIdForRetriedRow() async throws {
         let row = PendingOutcome(photoId: 11, payload: samplePayload)
         row.retryCount = 2
         row.nextRetryAt = Date().addingTimeInterval(-1)
@@ -524,6 +525,112 @@ final class OutcomeQueueManagerTests: XCTestCase {
         XCTAssertEqual(seenHeaders.count, 1, "precondition: one POST")
         XCTAssertEqual(seenHeaders.first, row.id.uuidString.lowercased(),
                        "Retry attempts must reuse PendingOutcome.id — otherwise server dedup is useless")
+    }
+
+    /// Swift2_018c G-3 — F-6 cross-drain stability. Drives TWO POSTs
+    /// for the same row (first 500 → row stays `.pending` with bumped
+    /// retryCount; force-reset `nextRetryAt` so the second drain re-
+    /// fires; second 200 → row delivered). Both `Idempotency-Key`
+    /// headers MUST be byte-identical to `row.id.uuidString.lowercased()`
+    /// — otherwise server dedup is useless on the very retry path the
+    /// header was added to support.
+    func testOutcomeRetryKeyIsStableAcrossMultiplePosts() async throws {
+        let row = PendingOutcome(photoId: 13, payload: samplePayload)
+        row.nextRetryAt = Date().addingTimeInterval(-1)
+        context.insert(row)
+        try context.save()
+        let originalId = row.id
+
+        var postCount = 0
+        var seenHeaders: [String] = []
+        let client = makeMockAPIClient { [self] request in
+            postCount += 1
+            if let h = request.value(forHTTPHeaderField: "Idempotency-Key") {
+                seenHeaders.append(h)
+            }
+            // First POST 500 (retryable), second POST 200 (delivered).
+            let code = postCount == 1 ? 500 : 200
+            return (mockResponse(statusCode: code, for: request), Data("{}".utf8))
+        }
+
+        await sut.drain(context: context, apiClient: client)
+
+        // After first drain the row should be back to .pending with
+        // retryCount = 1 and nextRetryAt in the future. Reset it to
+        // the past so the second drain re-fires the same row.
+        let refreshed = try XCTUnwrap(
+            try context.fetch(FetchDescriptor<PendingOutcome>()).first
+        )
+        XCTAssertEqual(refreshed.status, .pending,
+                       "precondition: 5xx must leave row pending for retry")
+        XCTAssertEqual(refreshed.retryCount, 1,
+                       "precondition: retryCount must bump on 5xx")
+        XCTAssertEqual(refreshed.id, originalId,
+                       "precondition: row id MUST NOT change on retry — that's the whole F-6 contract")
+        refreshed.nextRetryAt = Date().addingTimeInterval(-1)
+        try context.save()
+
+        await sut.drain(context: context, apiClient: client)
+
+        XCTAssertEqual(postCount, 2, "Two POSTs expected — one per drain")
+        XCTAssertEqual(seenHeaders.count, 2,
+                       "Both POSTs must carry an Idempotency-Key header")
+        XCTAssertEqual(seenHeaders[0], originalId.uuidString.lowercased(),
+                       "First POST header must equal refreshed.id.uuidString.lowercased()")
+        XCTAssertEqual(seenHeaders[1], originalId.uuidString.lowercased(),
+                       "Second POST header must equal refreshed.id.uuidString.lowercased() — server dedup pivots on this")
+        XCTAssertEqual(seenHeaders[0], seenHeaders[1],
+                       "Both retry headers MUST be byte-identical")
+    }
+
+    // MARK: - Swift2_018c SEC-26-2 — bounded reclaim per launch
+
+    /// Reclaim must not re-fire an unbounded number of orphaned `.sending`
+    /// rows in one launch — a crash loop would otherwise turn recovery
+    /// into a self-DoS. Cap at `maxReclaimPerLaunch` (100) and surface
+    /// the cap-hit via `lastReclaimCapHit` for telemetry.
+    func testReclaimCapsAtMaxReclaimPerLaunch() throws {
+        // Seed 150 .sending rows.
+        for i in 0..<150 {
+            let row = PendingOutcome(photoId: i, payload: samplePayload)
+            row.status = .sending
+            context.insert(row)
+        }
+        try context.save()
+
+        sut.reclaimOrphanedSendingRows(context: context)
+
+        let rows = try context.fetch(FetchDescriptor<PendingOutcome>())
+        let pendingCount = rows.filter { $0.status == .pending }.count
+        let sendingCount = rows.filter { $0.status == .sending }.count
+
+        XCTAssertEqual(pendingCount, OutcomeQueueManager.maxReclaimPerLaunch,
+                       "Exactly maxReclaimPerLaunch rows must be flipped to .pending")
+        XCTAssertEqual(sendingCount, 150 - OutcomeQueueManager.maxReclaimPerLaunch,
+                       "Remaining .sending rows must wait for the next launch")
+        XCTAssertTrue(sut.lastReclaimCapHit,
+                      "Cap-hit flag must be true so production observers see the warning condition")
+        XCTAssertEqual(sut.lastReclaimCount, OutcomeQueueManager.maxReclaimPerLaunch,
+                       "lastReclaimCount must equal the cap when the cap was hit")
+    }
+
+    /// Sanity check: under the cap, reclaim must NOT trip the warning
+    /// flag. Pins the contract so a future regression that always-trips
+    /// the flag would surface here.
+    func testReclaimUnderCapDoesNotTripWarning() throws {
+        for i in 0..<5 {
+            let row = PendingOutcome(photoId: i, payload: samplePayload)
+            row.status = .sending
+            context.insert(row)
+        }
+        try context.save()
+
+        sut.reclaimOrphanedSendingRows(context: context)
+
+        XCTAssertFalse(sut.lastReclaimCapHit,
+                       "Reclaiming 5 << cap must NOT trip the warning flag")
+        XCTAssertEqual(sut.lastReclaimCount, 5,
+                       "lastReclaimCount must reflect actual reclaim count when under cap")
     }
 
     // MARK: - Observable counts

--- a/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
+++ b/Bin Brain/Bin BrainTests/PendingOutcomeTests.swift
@@ -166,4 +166,135 @@ final class PendingOutcomeTests: XCTestCase {
         XCTAssertEqual(rows.first?.status, .pending,
                        "Int raw value of the status enum must round-trip — frozen values per PendingOutcome doc")
     }
+
+    // MARK: - Swift2_018c G-2 — expanded on-disk round-trip
+
+    /// Helper: opens a file-backed container, runs `seed`, tears it down,
+    /// reopens, and returns the rebuilt rows. `seed` runs against a fresh
+    /// `ModelContext` paired with the launch-1 container.
+    private func roundTripOnDisk<R>(
+        seed: (ModelContext) throws -> R,
+        verify: (ModelContext) throws -> Void
+    ) throws -> R {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pendingoutcome-rt-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+            try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("wal"))
+            try? FileManager.default.removeItem(at: tempURL.appendingPathExtension("shm"))
+        }
+        let result: R
+        do {
+            let schema = Schema([PendingOutcome.self])
+            let config = ModelConfiguration(schema: schema, url: tempURL)
+            let container1 = try ModelContainer(for: schema, configurations: config)
+            let ctx1 = ModelContext(container1)
+            result = try seed(ctx1)
+            try ctx1.save()
+        }
+        let schema = Schema([PendingOutcome.self])
+        let config = ModelConfiguration(schema: schema, url: tempURL)
+        let container2 = try ModelContainer(for: schema, configurations: config)
+        let ctx2 = ModelContext(container2)
+        try verify(ctx2)
+        return result
+    }
+
+    /// QA PR #26 §178–190 — payload Data must survive the SQLite write
+    /// path byte-for-byte, including arbitrary binary content.
+    func testPayloadRoundTripsByteForByte() throws {
+        let payload = Data((0...255).map { UInt8($0) })  // every possible byte
+        try roundTripOnDisk(
+            seed: { ctx in
+                let row = PendingOutcome(photoId: 1, payload: payload)
+                ctx.insert(row)
+            },
+            verify: { ctx in
+                let rows = try ctx.fetch(FetchDescriptor<PendingOutcome>())
+                XCTAssertEqual(rows.count, 1)
+                XCTAssertEqual(rows.first?.payload, payload,
+                               "payload Data must round-trip every byte 0x00-0xFF")
+            }
+        )
+    }
+
+    /// QA PR #26 §178–190 — queuedAt and nextRetryAt timestamps must
+    /// round-trip without drifting (small tolerance for SwiftData's
+    /// Date precision).
+    func testDatesRoundTripThroughStore() throws {
+        let queuedAt = Date(timeIntervalSince1970: 1_700_000_000.123)
+        let nextRetryAt = queuedAt.addingTimeInterval(3600)
+        try roundTripOnDisk(
+            seed: { ctx in
+                let row = PendingOutcome(photoId: 1, payload: Data())
+                row.queuedAt = queuedAt
+                row.nextRetryAt = nextRetryAt
+                ctx.insert(row)
+            },
+            verify: { ctx in
+                let rows = try ctx.fetch(FetchDescriptor<PendingOutcome>())
+                let row = try XCTUnwrap(rows.first)
+                XCTAssertEqual(row.queuedAt.timeIntervalSinceReferenceDate,
+                               queuedAt.timeIntervalSinceReferenceDate,
+                               accuracy: 0.001,
+                               "queuedAt must round-trip within sub-millisecond tolerance")
+                XCTAssertEqual(row.nextRetryAt.timeIntervalSinceReferenceDate,
+                               nextRetryAt.timeIntervalSinceReferenceDate,
+                               accuracy: 0.001,
+                               "nextRetryAt must round-trip within sub-millisecond tolerance")
+            }
+        )
+    }
+
+    /// QA PR #26 §178–190 — `lastErrorCode` is `Int?` and the nil case
+    /// is the most common (default on every fresh row). Both nil and
+    /// a non-nil value must round-trip.
+    func testLastErrorCodeNilRoundTrips() throws {
+        try roundTripOnDisk(
+            seed: { ctx in
+                let row = PendingOutcome(photoId: 1, payload: Data())
+                row.lastErrorCode = nil
+                ctx.insert(row)
+            },
+            verify: { ctx in
+                let rows = try ctx.fetch(FetchDescriptor<PendingOutcome>())
+                XCTAssertNil(rows.first?.lastErrorCode,
+                             "lastErrorCode nil must persist as nil — Optional<Int> column must not coerce to 0")
+            }
+        )
+    }
+
+    func testLastErrorCodeNonNilRoundTrips() throws {
+        try roundTripOnDisk(
+            seed: { ctx in
+                let row = PendingOutcome(photoId: 1, payload: Data())
+                row.lastErrorCode = 500
+                ctx.insert(row)
+            },
+            verify: { ctx in
+                let rows = try ctx.fetch(FetchDescriptor<PendingOutcome>())
+                XCTAssertEqual(rows.first?.lastErrorCode, 500,
+                               "non-nil lastErrorCode must round-trip exactly")
+            }
+        )
+    }
+
+    /// QA PR #26 §192–200 — every OutcomeQueueStatus raw value must
+    /// round-trip. Frozen-int contract per the model's doc comment.
+    func testAllStatusRawValuesRoundTrip() throws {
+        for status in [OutcomeQueueStatus.pending, .sending, .delivered, .expired] {
+            try roundTripOnDisk(
+                seed: { ctx in
+                    let row = PendingOutcome(photoId: status.rawValue, payload: Data())
+                    row.status = status
+                    ctx.insert(row)
+                },
+                verify: { ctx in
+                    let rows = try ctx.fetch(FetchDescriptor<PendingOutcome>())
+                    XCTAssertEqual(rows.first?.status, status,
+                                   "OutcomeQueueStatus.\(status) raw value (\(status.rawValue)) must round-trip exactly")
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Swift2_018c — Queue polish + delivered-TTL doc fix

Closes the 5 deferred items from PR #26 and the open F-4 doc thread from PR #23. All six items live; one (F-4) became doc-only after Architect scope check (the inline delete behavior already shipped in PR #26's `expireAged()`).

## Bundle contents

| Item | Where | What |
|------|-------|------|
| **G-1** + **SEC-26-1** | `OutcomeQueueManager.attemptDelivery` | Rewrote the CAS comment to describe de-facto MainActor isolation honestly. Class is intentionally NOT `@MainActor`; production callers (`SuggestionReviewViewModel.fireOutcomesIfReady`, `runMonitoredDrain`, scenePhase observer in `Bin_BrainApp`) all route through MainActor before invoking us. Future non-MainActor callers MUST add explicit serialization, or this guard needs hardening. No behavior change. |
| **G-2** | `PendingOutcomeTests.swift` | Added a `roundTripOnDisk(seed:verify:)` helper and 5 file-backed round-trip tests: payload byte-for-byte across all 256 byte values, `queuedAt`/`nextRetryAt` within sub-millisecond, `lastErrorCode` nil and non-nil separately, and parametrized `OutcomeQueueStatus` raw-value across all four cases. |
| **G-3** | `OutcomeQueueManagerTests.swift` | Renamed `testOutcomeRetryReusesSameIdempotencyKey` → `testOutcomePostHeaderEqualsRowIdForRetriedRow` (honest scope; it's a single-POST smoke). Added `testOutcomeRetryKeyIsStableAcrossMultiplePosts` that drives 2 POSTs (500 → 200), force-resets `nextRetryAt` between drains, and asserts both `Idempotency-Key` headers are byte-identical to `refreshed.id.uuidString.lowercased()`. |
| **SEC-26-2** | `OutcomeQueueManager.reclaimOrphanedSendingRows` | Bounded reclaim per launch at `maxReclaimPerLaunch = 100`. A crash-loop generating thousands of orphaned `.sending` rows would otherwise turn launch-time recovery into a self-DoS. Cap fires `logger.warning` + breaks; remaining rows wait for next launch (bounded forward progress). New `lastReclaimCapHit: Bool` and `lastReclaimCount: Int` `private(set)` properties for tests + future telemetry. Two new tests: cap-hit (150 seeded → 100 flipped, 50 untouched, flag true) and under-cap negative (5 seeded → flag false). |
| **F-4** (PR #23) | `PendingOutcome.OutcomeQueueStatus.delivered` doc | **Doc-only fix.** Architect scope-checked at my push-back: `expireAged()` has been deleting `.delivered` rows past TTL since PR #26 (commit `236b35b`). The Swift2_018c prompt asked for a separate `sweepDeliveredOlderThan()` + app-wiring + 3 tests against a method that doesn't need to exist. Per Architect's reply, the only F-4 work left was updating the comment from "swept" to "deleted" to match shipped behavior. The launch-time-vs-drain-time variant is pathological enough to be a future Swift2_018d if telemetry ever shows the gap. |

## Tests

- Full `Bin BrainTests` target: **green** on iPhone 17 sim.
- Queue + outcome suites: 9 new cases all pass (5 round-trip + 1 retry-key stability + 2 reclaim-cap + 1 renamed smoke).
- Suite run time: ~52 s (parallel sim clones).

## Size

| Bucket | Budget | Actual | Notes |
|--------|--------|--------|-------|
| Production LOC | < 100 | **61** | OutcomeQueueManager (+56) + PendingOutcome (+5) |
| Test LOC | < 200 | **246** | PendingOutcomeTests (+131) + OutcomeQueueManagerTests (+115). ~23% over budget — same situation as Swift2_019c: cohesive single-file additions in two files. The G-2 helper alone is ~30 LOC (loadbearing across 5 tests). Splitting into a separate PR would be procedural churn. Flagging explicitly. |

## Commits (logical chunks)

1. `80193e6` — polish(outcomes): CAS comment + reclaim cap + delivered-TTL doc
2. `0f3dfd0` — test(outcomes): on-disk round-trip + retry-key + reclaim cap

## Explicitly NOT in scope

- SEC-26-3 (server-side payload-binding for idempotency-key) — ApiDev PR.
- SEC-26-4/5/6/7 — info-only, unchanged deferral.
- PR #23 F-7/F-8/F-9/F-10/F-11 — still deferred.
- `dispatchPrecondition` hardening on the CAS — kept G-1 surface tight per prompt.
- Separate `sweepDeliveredOlderThan()` method — collapsed to doc-only per Architect scope check (see F-4 row above).

## References

- Prompt: `binbrain/.swarm/Prompts/Swift2_018c_queue_polish_and_ttl_sweep.md`
- QA PR #26: `binbrain/.swarm/AssessmentReports/QA_iOS_PR26_041926.md`
- SEC PR #26: `binbrain/.swarm/AssessmentReports/SEC_iOS_PR26_041926.md`
- QA PR #23 F-4: `binbrain/.swarm/AssessmentReports/QA_iOS_PR23_041926.md`
