### PR TITLE
fix(cataloging): show Vision label as default name in Review Items, not DB match (Swift_match_name_display_fix)

### DIFF
--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -352,7 +352,15 @@ final class SuggestionReviewViewModel {
         let initialState: OutcomeState = threeStateEnabled ? .ignored : .accepted
         let initialIncluded = (initialState == .accepted)
         editableSuggestions = suggestions.enumerated().map { idx, item in
-            let name = item.match?.name ?? item.name
+            // Vision label is the authoritative default. A DB match that
+            // passed the similarity threshold can still be semantically wrong
+            // (screw box 95% vs. unrelated catalogue item, BME688 87% vs.
+            // random part); letting match.name win silently poisoned the
+            // catalogue + YOLO-World training when the user tapped Confirm
+            // without editing. The match is still surfaced via the
+            // "also in catalog" disclosure line in the row view, and the
+            // user can one-tap adopt it there if they actually want it.
+            let name = item.name
             let category = item.match?.category ?? item.category ?? ""
             return EditableSuggestion(
                 id: idx,
@@ -580,6 +588,21 @@ final class SuggestionReviewViewModel {
         }
     }
 
+    /// Replaces `editedName` / `editedCategory` with the catalogue match's
+    /// values. No-op when the row has no match. Invoked by the row-view's
+    /// "also in catalog: ..." disclosure button — the one-tap adopt path.
+    /// Counts as a user edit, so `noteUserEdit` is chained to preserve the
+    /// merge + outcome-classification rules that fire off it.
+    func adoptMatchName(id: Int) {
+        guard let idx = editableSuggestions.firstIndex(where: { $0.id == id }) else { return }
+        guard let match = editableSuggestions[idx].match else { return }
+        editableSuggestions[idx].editedName = match.name
+        if let category = match.category, !category.isEmpty {
+            editableSuggestions[idx].editedCategory = category
+        }
+        noteUserEdit(id: id)
+    }
+
     /// Reconciles the current preliminary chips with the server's suggestions.
     ///
     /// Behavior (from the merge-UX spike §2a):
@@ -671,7 +694,11 @@ final class SuggestionReviewViewModel {
         for item in server {
             let key = Self.normalize(item.name)
             if editedNames.contains(key) { continue }
-            let name = item.match?.name ?? item.name
+            // Swift_match_name_display_fix — Vision label is authoritative.
+            // Mirror the `loadSuggestions` prefill so merge-path chips carry
+            // the same default as direct-load chips. The disclosure tap in
+            // the row view adopts match.name when the user wants it.
+            let name = item.name
             let category = item.match?.category ?? item.category ?? ""
             result.append(
                 EditableSuggestion(
@@ -739,12 +766,15 @@ final class SuggestionReviewViewModel {
             let finalLabel = item.editedName.trimmingCharacters(in: .whitespacesAndNewlines)
             let originalLabel = item.visionName
             // Edit-detection baseline is the value `editedName` was PREFILLED
-            // with — which is `match.name` when a catalogue match exists,
-            // NOT `visionName`. Comparing against `visionName` alone would
-            // false-flag every catalogue-matched but untouched confirmation
-            // as `.edited` (poisoning the training signal Swift2_014 exists
-            // to collect — see ultrareview bug_001).
-            let prefilledLabel = item.match?.name ?? item.visionName
+            // with — which is `visionName` in every case since the
+            // Swift_match_name_display_fix change. An earlier contract
+            // prefilled from `match.name` when a catalogue match existed,
+            // but that let bogus matches poison the training signal on
+            // Confirm, so the prefill is now always Vision. The user can
+            // still one-tap adopt `match.name` via the row's match-disclosure
+            // line — that flow is a genuine edit and correctly emits
+            // `.edited` under this baseline.
+            let prefilledLabel = item.visionName
             let labelChanged = !finalLabel.isEmpty && finalLabel != prefilledLabel
 
             let decision: PhotoSuggestionOutcome.Decision

--- a/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/SuggestionReviewView.swift
@@ -286,25 +286,32 @@ struct SuggestionReviewView: View {
                 }
             }
 
-            if s.isMatched {
-                HStack(spacing: 4) {
-                    Image(systemName: "link")
-                        .font(.caption2)
-                        .accessibilityHidden(true)
-                    Text("Matched to catalogue")
-                        .font(.caption)
-                    if s.visionName != s.editedName {
-                        Text("(vision: \(s.visionName))")
+            if let match = s.match {
+                // Swift_match_name_display_fix — the primary title (Text at
+                // top of the row) now shows the Vision label. The catalogue
+                // match is surfaced here as a disclosure line so the user
+                // can see it exists without it silently overriding the name
+                // they're about to confirm. Tapping the line adopts the
+                // match — one-tap path for users who actually want it.
+                Button {
+                    viewModel.adoptMatchName(id: s.id)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "link")
+                            .font(.caption2)
+                            .accessibilityHidden(true)
+                        Text("also in catalog: \(match.name)")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                    if let score = s.match?.score {
                         Spacer()
-                        Text(String(format: "%.0f%% similar", score * 100))
+                        Text(String(format: "%.0f%%", match.score * 100))
                             .font(.caption)
                     }
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
                 }
-                .foregroundStyle(.secondary)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Adopt catalogue match \(match.name), \(Int(match.score * 100)) percent similar")
+                .accessibilityHint("Replaces the name with the catalogue match")
             }
 
             TextField("Name", text: suggestion.editedName)

--- a/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
+++ b/Bin Brain/Bin BrainTests/PhotoSuggestionOutcomesTests.swift
@@ -373,24 +373,31 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
         XCTAssertTrue(outcomes.isEmpty, "no presented suggestions → no decisions")
     }
 
-    // MARK: - 10. Regression — catalogue-matched untouched → .accepted (ultrareview bug_001)
+    // MARK: - 10. Regression — catalogue-matched untouched → .accepted
+    //
+    // History:
+    // - ultrareview bug_001 (pre-fix): `loadSuggestions` prefilled
+    //   `editedName` from `match.name`, so naïve `editedName != visionName`
+    //   edit-detection false-flagged every untouched match as `.edited`.
+    //   Fix was to baseline against `match.name ?? visionName`.
+    // - Swift_match_name_display_fix (2026-04-20): `loadSuggestions` now
+    //   prefills from `visionName` regardless of match (bogus matches were
+    //   poisoning the catalogue on Confirm). Baseline correspondingly
+    //   simplified to `visionName`. The "untouched → .accepted" invariant
+    //   must still hold under both contracts.
 
-    /// When a server suggestion carries a `SuggestionMatch`, `loadSuggestions`
-    /// pre-fills `editedName` from `match.name` (not `visionName`). A naïve
-    /// `editedName != visionName` edit-detection would false-flag every
-    /// matched-but-untouched confirmation as `.edited`, poisoning the training
-    /// signal. `buildOutcomes` must compare against the pre-fill baseline
-    /// (`match.name ?? visionName`) so untouched matched items stay `.accepted`.
+    /// Untouched matched row — `editedName` is the Vision label (the new
+    /// prefill) — must classify as `.accepted`.
     func testBuildOutcomes_catalogueMatchedUntouchedItemClassifiedAsAccepted() {
         let match = SuggestionMatchFixture.hexNutM3
         let matched = EditableSuggestion(
             id: 0,
             included: true,
-            editedName: match.name,       // pre-filled from match.name by loadSuggestions
+            editedName: "hex nut",         // pre-filled from visionName per Swift_match_name_display_fix
             editedCategory: match.category ?? "",
             editedQuantity: "",
             confidence: 0.9,
-            visionName: "hex nut",         // raw VLM label — diverges from editedName at load time
+            visionName: "hex nut",
             match: match,
             bbox: nil,
             teach: true,
@@ -404,20 +411,19 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
         )
         XCTAssertEqual(outcomes.count, 1)
         XCTAssertEqual(outcomes[0].decision, .accepted,
-                       "matched, user-untouched item must be .accepted — comparing editedName to visionName alone would wrongly emit .edited")
+                       "matched, user-untouched item must be .accepted when editedName == visionName")
         XCTAssertNil(outcomes[0].editedToLabel)
         XCTAssertEqual(outcomes[0].label, "hex nut",
-                       "label must be the raw VLM signal (visionName), not the catalogue match name")
+                       "label must be the raw VLM signal (visionName)")
     }
 
-    /// And confirm the real-edit path still fires when the user overrides a
-    /// matched pre-fill — the baseline shift must not suppress genuine edits.
+    /// Real-edit path: user typed a distinct name. Must classify as `.edited`.
     func testBuildOutcomes_catalogueMatchedThenUserEditedStillEmitsEdited() {
         let match = SuggestionMatchFixture.hexNutM3
         let edited = EditableSuggestion(
             id: 0,
             included: true,
-            editedName: "M3 stainless nut", // user overrode the match prefill
+            editedName: "M3 stainless nut", // user typed a new name
             editedCategory: "fastener",
             editedQuantity: "",
             confidence: 0.9,
@@ -436,6 +442,37 @@ final class PhotoSuggestionOutcomesTests: XCTestCase {
         XCTAssertEqual(outcomes[0].decision, .edited)
         XCTAssertEqual(outcomes[0].label, "hex nut")
         XCTAssertEqual(outcomes[0].editedToLabel, "M3 stainless nut")
+    }
+
+    /// Swift_match_name_display_fix adopt-match path: user tapped the
+    /// "also in catalog" disclosure, replacing `editedName` with `match.name`.
+    /// That is a genuine user edit and must emit `.edited` with the match
+    /// name as `editedToLabel`.
+    func testBuildOutcomes_userAdoptedCatalogueMatchEmitsEdited() {
+        let match = SuggestionMatchFixture.hexNutM3
+        let adopted = EditableSuggestion(
+            id: 0,
+            included: true,
+            editedName: match.name, // user tapped disclosure → adopted match.name
+            editedCategory: match.category ?? "",
+            editedQuantity: "",
+            confidence: 0.9,
+            visionName: "hex nut",
+            match: match,
+            bbox: nil,
+            teach: true,
+            origin: .edited,
+            originalCategory: "fastener"
+        )
+        let outcomes = SuggestionReviewViewModel.buildOutcomes(
+            shownAt: fixedShownAt,
+            editable: [adopted],
+            confirmedIds: [0]
+        )
+        XCTAssertEqual(outcomes[0].decision, .edited,
+                       "adopting the catalogue match via the disclosure tap is a genuine edit")
+        XCTAssertEqual(outcomes[0].label, "hex nut")
+        XCTAssertEqual(outcomes[0].editedToLabel, match.name)
     }
 
     // MARK: - 11. Regression — shownAt restamps on fresh session (ultrareview bug_003)

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelTests.swift
@@ -409,9 +409,17 @@ final class SuggestionReviewViewModelTests: XCTestCase {
         )
     }
 
-    // MARK: - Test 9: loadSuggestions prefers match name/category
+    // MARK: - Test 9: loadSuggestions defaults editedName to Vision label
+    //
+    // Swift_match_name_display_fix (2026-04-20) — previously this test
+    // asserted that `match.name` won the prefill race. That contract was
+    // poisoning the catalogue on Confirm when the similarity match was
+    // semantically bogus (screw box 95% vs. unrelated item, BME688 87%).
+    // The new contract: `editedName` is prefilled from the raw Vision label
+    // regardless of match presence; match is surfaced for display only and
+    // can be one-tap adopted via `adoptMatchName(id:)`.
 
-    func testLoadSuggestionsUsesMatchNameWhenAvailable() throws {
+    func testLoadSuggestionsDefaultsEditedNameToVisionLabelEvenWhenMatched() throws {
         let json = Data("""
         [
             {
@@ -442,8 +450,12 @@ final class SuggestionReviewViewModelTests: XCTestCase {
 
         sut.loadSuggestions(suggestions)
 
-        // First: matched — should use catalogue name/category
-        XCTAssertEqual(sut.editableSuggestions[0].editedName, "Hex Nut M3")
+        // First: matched — editedName MUST be Vision label, NOT match.name.
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "hex nut",
+                       "editedName must default to Vision label, not match.name — match.name wins was the data-poisoning bug Swift_match_name_display_fix addressed")
+        // Category still preferentially uses the catalogue match's category
+        // since that's lower-risk than a free-text name override and the
+        // Vision category is often missing. Intentional.
         XCTAssertEqual(sut.editableSuggestions[0].editedCategory, "Fasteners")
         XCTAssertEqual(sut.editableSuggestions[0].visionName, "hex nut")
         XCTAssertTrue(sut.editableSuggestions[0].isMatched)
@@ -456,6 +468,120 @@ final class SuggestionReviewViewModelTests: XCTestCase {
         XCTAssertEqual(sut.editableSuggestions[1].visionName, "mystery part")
         XCTAssertFalse(sut.editableSuggestions[1].isMatched)
         XCTAssertNil(sut.editableSuggestions[1].match)
+    }
+
+    func testLoadSuggestionsDefaultsToVisionNameAcrossMatchScores() throws {
+        // Vision wins regardless of match confidence — the core invariant
+        // of Swift_match_name_display_fix. Even a 0.99 match (the kind that
+        // looks like a legit hit) must not override the Vision label.
+        for score in [0.51, 0.75, 0.87, 0.95, 0.99] {
+            sut = SuggestionReviewViewModel()
+            sut.threeStateEnabled = false
+            let json = Data("""
+            [{
+                "item_id": null,
+                "name": "screw box",
+                "category": null,
+                "confidence": 0.9,
+                "bins": [],
+                "match": {
+                    "item_id": 1,
+                    "name": "Arduino Uno Rev3",
+                    "category": "Electronics",
+                    "score": \(score),
+                    "bins": ["A-1"]
+                }
+            }]
+            """.utf8)
+            let suggestions = try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+            sut.loadSuggestions(suggestions)
+            XCTAssertEqual(sut.editableSuggestions[0].editedName, "screw box",
+                           "Vision label must survive as the prefilled editedName even at match score \(score)")
+        }
+    }
+
+    func testAdoptMatchNameReplacesEditedNameWithCatalogueMatch() throws {
+        let json = Data("""
+        [{
+            "item_id": null,
+            "name": "hex nut",
+            "category": "hardware",
+            "confidence": 0.7,
+            "bins": [],
+            "match": {
+                "item_id": 42,
+                "name": "Hex Nut M3",
+                "category": "Fasteners",
+                "score": 0.9,
+                "bins": []
+            }
+        }]
+        """.utf8)
+        let suggestions = try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+        sut.loadSuggestions(suggestions)
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "hex nut")
+
+        sut.adoptMatchName(id: 0)
+
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "Hex Nut M3",
+                       "adoptMatchName must replace editedName with the catalogue match's name")
+        XCTAssertEqual(sut.editableSuggestions[0].editedCategory, "Fasteners")
+    }
+
+    func testAdoptMatchNameIsNoOpWhenMatchAbsent() throws {
+        let suggestions = try makeSuggestions()
+        sut.loadSuggestions(suggestions)
+        let before = sut.editableSuggestions[0].editedName
+
+        sut.adoptMatchName(id: 0)
+
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, before,
+                       "adoptMatchName must be a no-op on rows with no match")
+    }
+
+    func testConfirmSendsVisionNameWhenMatchedRowIsUntouched() async throws {
+        // The bug this test guards against: on Confirm with an untouched row
+        // that carries a (possibly bogus) catalogue match, the server used
+        // to receive match.name in the upsert body. After
+        // Swift_match_name_display_fix, the Vision label must go through.
+        let json = Data("""
+        [{
+            "item_id": null,
+            "name": "screw box",
+            "category": null,
+            "confidence": 0.9,
+            "bins": [],
+            "match": {
+                "item_id": 77,
+                "name": "Arduino Uno Rev3",
+                "category": "Electronics",
+                "score": 0.95,
+                "bins": []
+            }
+        }]
+        """.utf8)
+        let suggestions = try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+        sut.loadSuggestions(suggestions)
+
+        var capturedItemsBody: String?
+        let client = makeMockAPIClient { [self] request in
+            let path = request.url?.path ?? ""
+            if path == "/items", let data = request.bodyData {
+                capturedItemsBody = String(data: data, encoding: .utf8)
+            }
+            if path.hasSuffix("/associate") {
+                return (mockResponse(statusCode: 200, for: request), associateSuccessJSON)
+            }
+            return (mockResponse(statusCode: 200, for: request), upsertSuccessJSON)
+        }
+
+        await sut.confirm(binId: "BIN-0001", apiClient: client)
+
+        let bodyString = try XCTUnwrap(capturedItemsBody)
+        XCTAssertTrue(bodyString.contains("screw box"),
+                      "upsert body must carry the Vision label 'screw box', not the bogus match 'Arduino Uno Rev3'. Body was: \(bodyString)")
+        XCTAssertFalse(bodyString.contains("Arduino Uno Rev3"),
+                       "upsert body must NOT carry match.name when the user did not adopt the match")
     }
 
     // MARK: - Test 10: loadSuggestions without match preserves vision data


### PR DESCRIPTION
## Summary

Review Items was defaulting `editedName` to `match.name` (the DB-matched catalogue item) whenever a match was present, demoting the Vision label to a `(vision: <name>)` parenthetical. Tapping **Confirm** without editing then sent `match.name` to `POST /items`, silently poisoning the catalogue and YOLO-World training data whenever a bogus match squeaked past the similarity threshold. The server has no cross-check on inbound item names — iOS is the only place the correction can land.

**Vision is now authoritative.** The DB match is retained on the row and surfaced as a tappable "also in catalog" disclosure for one-tap adoption.

## Bug reproducers (from field)

| Vision label | DB match.name | Score | Outcome before fix |
| --- | --- | --- | --- |
| screw box | Arduino Uno Rev3 (unrelated) | 0.95 | Catalogue row written as "Arduino Uno Rev3" |
| BME688 sensor | (unrelated catalogue item) | 0.87 | Catalogue row written with wrong label |

## Before / after — `editedName` defaulting

```swift
// before (SuggestionReviewViewModel.loadSuggestions)
let name = item.match?.name ?? item.name   // match always wins when present

// after
let name = item.name                       // Vision is authoritative; match shown as disclosure
```

The same fallback existed on `merge(preliminary:server:)` and as the edit-detection baseline in `buildOutcomes` (where it would have false-flagged untouched matched rows as `.edited` once the prefill changed). All three pivoted in one commit.

## Row view

- Removed: `(vision: <name>)` demotion subtitle
- Added: `"also in catalog: <match.name> (NN%)"` disclosure wired as a `Button` invoking the new `SuggestionReviewViewModel.adoptMatchName(id:)` helper. Adopt = user edit → emits `.edited`.

## Confirm-flow coverage (new test)

`testConfirmSendsVisionNameWhenMatchedRowIsUntouched` (`SuggestionReviewViewModelTests`) — mocks `/items` + `/associate`, creates a `screw box` Vision suggestion with a bogus `Arduino Uno Rev3` match at 0.95, confirms without editing, and asserts the captured `POST /items` body contains `"screw box"` and does NOT contain `"Arduino Uno Rev3"`.

## Test coverage

**Updated**
- `testLoadSuggestionsUsesMatchNameWhenAvailable` → renamed to `testLoadSuggestionsDefaultsEditedNameToVisionLabelEvenWhenMatched`, assertion inverted
- `testBuildOutcomes_catalogueMatchedUntouchedItemClassifiedAsAccepted` — baseline is now `visionName`

**Added**
- `testLoadSuggestionsDefaultsToVisionNameAcrossMatchScores` — loops `[0.51, 0.75, 0.87, 0.95, 0.99]`, Vision wins every time
- `testAdoptMatchNameReplacesEditedNameWithCatalogueMatch`
- `testAdoptMatchNameIsNoOpWhenMatchAbsent`
- `testConfirmSendsVisionNameWhenMatchedRowIsUntouched`
- `testBuildOutcomes_userAdoptedCatalogueMatchEmitsEdited`

Full `Bin Brain` scheme suite: `** TEST SUCCEEDED **` on iPhone 17 / iOS 26.4.

## Scope

- iOS-only. No server or `openapi.yaml` changes.
- NOT the dismiss-leaves-photos bug. NOT the Index-out-of-range crash.
- **Server-side `match.is_promotable` is a parked follow-up, NOT in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-tap button to adopt catalogue-matched item names

* **UI/UX Improvements**
  * Updated catalogue match disclosure to display "also in catalog: [name]" with similarity percentage
  * Vision-generated labels now default for untouched matched items

* **Bug Fixes**
  * Fixed false edit detection for untouched catalogue-matched items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->