### PR TITLE
feat(cataloging): OCR preliminary chips — iOS uses local Vision OCR findings (Swift_prong1_ocr_preliminary)

### DIFF
--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -59,6 +59,14 @@ final class AnalysisViewModel {
     /// `thoughts/shared/designs/coreml-mode-a-merge-ux.md`.
     private(set) var preliminaryClassifications: [ClassificationResult] = []
 
+    /// Swift_prong1_ocr_preliminary — on-device OCR results from the same
+    /// Stage 3 `MetadataExtractors.extract(from:)` call that produces
+    /// `preliminaryClassifications`. Published alongside classifications so
+    /// the preliminary-ready callback can thread them into
+    /// `SuggestionReviewViewModel.loadPreliminaryFromOnDevice(...)` where
+    /// the confidence + length bar decides whether an OCR chip lands.
+    private(set) var preliminaryOCR: [OCRResult] = []
+
     /// The photo ID from the last successful ingest; `nil` until ingest completes.
     private(set) var lastPhotoId: Int?
 
@@ -142,6 +150,7 @@ final class AnalysisViewModel {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         preliminaryClassifications = []
+        preliminaryOCR = []
 
         // Boxes allow mutation from the synchronously-called expiration handler.
         final class WorkTaskBox: @unchecked Sendable {
@@ -199,6 +208,7 @@ final class AnalysisViewModel {
             let result = try await pipeline.process(jpegData)
             uploadData = result.optimizedImageData
             preliminaryClassifications = result.deviceMetadata.deviceProcessing.classifications
+            preliminaryOCR = result.deviceMetadata.deviceProcessing.ocr
             let jsonData = try JSONEncoder().encode(result.deviceMetadata)
             metadataString = String(data: jsonData, encoding: .utf8)
         } catch let error as PipelineError {
@@ -329,6 +339,7 @@ final class AnalysisViewModel {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
         preliminaryClassifications = []
+        preliminaryOCR = []
         phase = .processingImage
 
         var uploadData: Data
@@ -338,6 +349,7 @@ final class AnalysisViewModel {
             let result = try await pipeline.processSkippingQualityGates(jpegData)
             uploadData = result.optimizedImageData
             preliminaryClassifications = result.deviceMetadata.deviceProcessing.classifications
+            preliminaryOCR = result.deviceMetadata.deviceProcessing.ocr
             let jsonData = try JSONEncoder().encode(result.deviceMetadata)
             metadataString = String(data: jsonData, encoding: .utf8)
         } catch {
@@ -432,6 +444,7 @@ final class AnalysisViewModel {
         phase = .idle
         suggestions = []
         preliminaryClassifications = []
+        preliminaryOCR = []
         lastPhotoId = nil
         lastVisionModel = nil
         lastPromptVersion = nil

--- a/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/SuggestionReviewViewModel.swift
@@ -25,6 +25,10 @@ enum ChipOrigin: Equatable {
     case server
     /// Modified by the user; survives any merge pass.
     case edited
+    /// On-device `VNRecognizeTextRequest` (OCR) result above the confidence
+    /// and length bar. Authoritative like `.edited` — survives merge so the
+    /// user never loses a high-confidence label the device already read.
+    case ocr
 }
 
 // MARK: - EditableSuggestion
@@ -547,6 +551,72 @@ final class SuggestionReviewViewModel {
         failedIndices = []
     }
 
+    /// Swift_prong1_ocr_preliminary — populates `editableSuggestions` from
+    /// on-device Vision results, combining `VNClassifyImageRequest`
+    /// classifications AND `VNRecognizeTextRequest` OCR findings.
+    ///
+    /// OCR selection rule (documented in the PR body): of the OCR entries
+    /// with `confidence >= minOCRConfidence` AND trimmed `text.count >=
+    /// minOCRLength`, the one with the longest text wins. No fallback to
+    /// sub-threshold entries — if nothing qualifies, no OCR chip is emitted
+    /// and the classifier chips stand alone. This keeps the bar high enough
+    /// that generic short words (e.g. "New" at 1.0) don't land as chips.
+    ///
+    /// OCR chips carry `origin = .ocr` so `merge(preliminary:server:)`
+    /// treats them like `.edited` chips — they survive the server response
+    /// and will dedupe against overlapping server names.
+    ///
+    /// - Parameters:
+    ///   - classifications: The on-device classification results from Stage 3.
+    ///   - ocr: The on-device OCR results from Stage 3.
+    ///   - topK: Maximum number of classifier chips. Same semantics as
+    ///     `loadPreliminaryClassifications`.
+    ///   - minOCRConfidence: Lower bound on OCR confidence (inclusive).
+    ///     Production default is `0.9`.
+    ///   - minOCRLength: Lower bound on trimmed text length (inclusive).
+    ///     Production default is `4` — avoids emitting trivial strings.
+    func loadPreliminaryFromOnDevice(
+        classifications: [ClassificationResult],
+        ocr: [OCRResult],
+        topK: Int,
+        minOCRConfidence: Float = 0.9,
+        minOCRLength: Int = 4
+    ) {
+        loadPreliminaryClassifications(classifications, topK: topK)
+
+        let qualifying = ocr.compactMap { result -> (text: String, confidence: Float)? in
+            let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard result.confidence >= minOCRConfidence, trimmed.count >= minOCRLength else {
+                return nil
+            }
+            return (trimmed, result.confidence)
+        }
+        guard let chosen = qualifying.max(by: { $0.text.count < $1.text.count }) else {
+            return
+        }
+
+        let initialState: OutcomeState = threeStateEnabled ? .ignored : .accepted
+        let initialIncluded = (initialState == .accepted)
+        let nextId = (editableSuggestions.map(\.id).max() ?? -1) + 1
+        editableSuggestions.append(
+            EditableSuggestion(
+                id: nextId,
+                included: initialIncluded,
+                editedName: chosen.text,
+                editedCategory: "",
+                editedQuantity: "",
+                confidence: Double(chosen.confidence),
+                visionName: chosen.text,
+                match: nil,
+                bbox: nil,
+                teach: true,
+                origin: .ocr,
+                originalCategory: nil,
+                outcomeState: initialState
+            )
+        )
+    }
+
     /// Marks the chip at `index` as user-edited so subsequent merges preserve it.
     ///
     /// Call from the view when the user modifies any editable field on a
@@ -680,10 +750,13 @@ final class SuggestionReviewViewModel {
         server: [SuggestionItem],
         threeStateEnabled: Bool = false
     ) -> [EditableSuggestion] {
-        let editedChips = preliminary.filter { $0.origin == .edited }
-        let editedNames = Set(editedChips.map { Self.normalize($0.editedName) })
+        // `.ocr` chips are treated like `.edited` for survival — they carry
+        // high-confidence on-device text that the user should never lose
+        // just because the server's VLM produced a generic label.
+        let survivorChips = preliminary.filter { $0.origin == .edited || $0.origin == .ocr }
+        let survivorNames = Set(survivorChips.map { Self.normalize($0.editedName) })
 
-        var result = editedChips
+        var result = survivorChips
         var nextId = (result.map(\.id).max() ?? -1) + 1
 
         // Server items added by merge follow the same three-state initial
@@ -693,7 +766,7 @@ final class SuggestionReviewViewModel {
         let initialIncluded = (initialState == .accepted)
         for item in server {
             let key = Self.normalize(item.name)
-            if editedNames.contains(key) { continue }
+            if survivorNames.contains(key) { continue }
             // Swift_match_name_display_fix — Vision label is authoritative.
             // Mirror the `loadSuggestions` prefill so merge-path chips carry
             // the same default as direct-load chips. The disclosure tap in

--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -339,10 +339,11 @@ struct BinDetailView: View {
                     )
                 }
             },
-            onPreliminaryReady: { classifications in
+            onPreliminaryReady: { classifications, ocr in
                 reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
-                reviewViewModel.loadPreliminaryClassifications(
-                    classifications,
+                reviewViewModel.loadPreliminaryFromOnDevice(
+                    classifications: classifications,
+                    ocr: ocr,
                     topK: Self.preliminaryTopK
                 )
                 navigatedOnPreliminary = true

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -269,10 +269,11 @@ struct BinsListView: View {
                     )
                 }
             },
-            onPreliminaryReady: { classifications in
+            onPreliminaryReady: { classifications, ocr in
                 reviewViewModel.photoData = analysisViewModel.lastUploadedPhotoData
-                reviewViewModel.loadPreliminaryClassifications(
-                    classifications,
+                reviewViewModel.loadPreliminaryFromOnDevice(
+                    classifications: classifications,
+                    ocr: ocr,
                     topK: Self.preliminaryTopK
                 )
                 navigatedOnPreliminary = true

--- a/Bin Brain/Bin Brain/Views/Cataloging/AnalysisProgressView.swift
+++ b/Bin Brain/Bin Brain/Views/Cataloging/AnalysisProgressView.swift
@@ -30,14 +30,15 @@ struct AnalysisProgressView: View {
     /// Called when the user taps "Upload Anyway" after a `.qualityFailed` phase.
     let onOverride: () -> Void
 
-    /// Called once, when on-device `VNClassifyImageRequest` classifications
-    /// become available (Stage 3 of `ImagePipeline` succeeded) — *before* the
-    /// ~40 s server call completes. The parent uses this to render preliminary
-    /// chips in `SuggestionReviewView` and navigate early, delivering the
-    /// Mode A perceived-latency win.
+    /// Called once, when on-device Vision extraction finishes (Stage 3 of
+    /// `ImagePipeline` succeeded) — *before* the ~40 s server call completes.
+    /// Carries both `VNClassifyImageRequest` classifications AND
+    /// `VNRecognizeTextRequest` OCR results so the parent can render
+    /// preliminary chips in `SuggestionReviewView` via
+    /// `SuggestionReviewViewModel.loadPreliminaryFromOnDevice(...)`.
     ///
     /// `nil` (default) preserves the pre-Mode-A blocking-progress behavior.
-    var onPreliminaryReady: (([ClassificationResult]) -> Void)?
+    var onPreliminaryReady: (([ClassificationResult], [OCRResult]) -> Void)?
 
     // MARK: - Private state
 
@@ -138,7 +139,7 @@ struct AnalysisProgressView: View {
                   !didFirePreliminary,
                   let onPreliminaryReady else { return }
             didFirePreliminary = true
-            onPreliminaryReady(viewModel.preliminaryClassifications)
+            onPreliminaryReady(viewModel.preliminaryClassifications, viewModel.preliminaryOCR)
         }
         .onChange(of: viewModel.phase) { _, newPhase in
             if case .idle = newPhase { didFirePreliminary = false }

--- a/Bin Brain/Bin BrainTests/PureMergeOCRSurvivalTests.swift
+++ b/Bin Brain/Bin BrainTests/PureMergeOCRSurvivalTests.swift
@@ -1,0 +1,153 @@
+// PureMergeOCRSurvivalTests.swift
+// Bin BrainTests
+//
+// Swift_prong1_ocr_preliminary — unit tests for the pure merge function's
+// handling of `origin == .ocr` chips. OCR chips must survive the server
+// response like `.edited` chips do, and server entries that normalize to
+// the same name as an OCR chip must be skipped (deduped).
+//
+// Driven against `SuggestionReviewViewModel.merge(preliminary:server:)`
+// directly so the contract is pinned at the function boundary, independent
+// of the VM's load paths.
+
+import XCTest
+@testable import Bin_Brain
+
+@MainActor
+final class PureMergeOCRSurvivalTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeOCR(id: Int, name: String, confidence: Double = 1.0) -> EditableSuggestion {
+        EditableSuggestion(
+            id: id,
+            included: true,
+            editedName: name,
+            editedCategory: "",
+            editedQuantity: "",
+            confidence: confidence,
+            visionName: name,
+            match: nil,
+            bbox: nil,
+            teach: true,
+            origin: .ocr,
+            originalCategory: nil
+        )
+    }
+
+    private func makePreliminary(id: Int, name: String) -> EditableSuggestion {
+        EditableSuggestion(
+            id: id,
+            included: true,
+            editedName: name,
+            editedCategory: "",
+            editedQuantity: "",
+            confidence: 0.8,
+            visionName: name,
+            match: nil,
+            bbox: nil,
+            teach: true,
+            origin: .preliminary,
+            originalCategory: nil
+        )
+    }
+
+    private func serverItems(_ names: [String]) throws -> [SuggestionItem] {
+        let items = names.map { name in
+            """
+            {"item_id": null, "name": "\(name)", "category": null, "confidence": 0.9, "bins": []}
+            """
+        }
+        let json = Data("[\(items.joined(separator: ","))]".utf8)
+        return try JSONDecoder.binBrain.decode([SuggestionItem].self, from: json)
+    }
+
+    // MARK: - Survival
+
+    func testOCRChipSurvivesEmptyServerResponse() {
+        let prelim = [makeOCR(id: 0, name: "Elegoo Ribbon Cables")]
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: [])
+
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged[0].editedName, "Elegoo Ribbon Cables")
+        XCTAssertEqual(merged[0].origin, .ocr)
+    }
+
+    func testOCRChipSurvivesServerDisagrees() throws {
+        let prelim = [makeOCR(id: 0, name: "Elegoo Ribbon Cables")]
+        let server = try serverItems(["label_packaging"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: server)
+
+        XCTAssertEqual(merged.count, 2)
+        XCTAssertEqual(merged[0].editedName, "Elegoo Ribbon Cables")
+        XCTAssertEqual(merged[0].origin, .ocr)
+        XCTAssertEqual(merged[1].editedName, "label_packaging")
+        XCTAssertEqual(merged[1].origin, .server)
+    }
+
+    func testServerEntryMatchingOCRNameIsDeduped() throws {
+        let prelim = [makeOCR(id: 0, name: "bolt kit")]
+        let server = try serverItems(["bolt kit", "screw"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: server)
+
+        XCTAssertEqual(merged.count, 2,
+                       "Server entry overlapping an OCR chip must be deduped")
+        XCTAssertEqual(merged[0].origin, .ocr,
+                       "OCR chip wins over overlapping server entry")
+        XCTAssertEqual(merged[1].editedName, "screw")
+        XCTAssertEqual(merged[1].origin, .server)
+    }
+
+    func testOCRDedupeIsCaseAndWhitespaceInsensitive() throws {
+        let prelim = [makeOCR(id: 0, name: "  Bolt Kit  ")]
+        let server = try serverItems(["bolt kit"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: server)
+
+        XCTAssertEqual(merged.count, 1,
+                       "Normalization (trim + lowercase) must catch this dedupe")
+        XCTAssertEqual(merged[0].origin, .ocr)
+    }
+
+    // MARK: - Coexistence with .edited and .preliminary
+
+    func testEditedAndOCRChipsBothSurvive() throws {
+        let prelim: [EditableSuggestion] = [
+            makePreliminary(id: 0, name: "nail"),
+            makeOCR(id: 1, name: "Elegoo Ribbon Cables")
+        ]
+        var edited = prelim
+        edited[0].editedName = "M3 screw"
+        edited[0].origin = .edited
+        let server = try serverItems(["bolt"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: edited, server: server)
+
+        XCTAssertEqual(merged.count, 3)
+        XCTAssertEqual(Set(merged.map(\.origin)), [.edited, .ocr, .server])
+        XCTAssertTrue(merged.contains(where: { $0.editedName == "M3 screw" && $0.origin == .edited }))
+        XCTAssertTrue(merged.contains(where: { $0.editedName == "Elegoo Ribbon Cables" && $0.origin == .ocr }))
+        XCTAssertTrue(merged.contains(where: { $0.editedName == "bolt" && $0.origin == .server }))
+    }
+
+    func testUntouchedPreliminaryIsStillDroppedWhenOCRSurvives() throws {
+        // Regression guard: .ocr survival must not accidentally resurrect
+        // .preliminary chips. Only .ocr and .edited qualify.
+        let prelim: [EditableSuggestion] = [
+            makePreliminary(id: 0, name: "nail"),
+            makeOCR(id: 1, name: "Elegoo Ribbon Cables")
+        ]
+        let server = try serverItems(["bolt"])
+
+        let merged = SuggestionReviewViewModel.merge(preliminary: prelim, server: server)
+
+        XCTAssertEqual(merged.count, 2)
+        XCTAssertFalse(merged.contains(where: { $0.editedName == "nail" }),
+                       "Untouched .preliminary must still be dropped when server returns")
+        XCTAssertTrue(merged.contains(where: { $0.editedName == "Elegoo Ribbon Cables" }))
+        XCTAssertTrue(merged.contains(where: { $0.editedName == "bolt" }))
+    }
+}

--- a/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
+++ b/Bin Brain/Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift
@@ -34,6 +34,10 @@ final class SuggestionReviewViewModelPreliminaryTests: XCTestCase {
         pairs.map { ClassificationResult(label: $0.0, confidence: $0.1) }
     }
 
+    private func ocrResults(_ pairs: [(String, Float)]) -> [OCRResult] {
+        pairs.map { OCRResult(text: $0.0, confidence: $0.1) }
+    }
+
     private func serverItems(_ names: [String]) throws -> [SuggestionItem] {
         let items = names.map { name in
             """
@@ -151,6 +155,135 @@ final class SuggestionReviewViewModelPreliminaryTests: XCTestCase {
         XCTAssertEqual(sut.editableSuggestions[0].origin, .edited)
         XCTAssertEqual(sut.editableSuggestions[1].editedName, "screw")
         XCTAssertEqual(sut.editableSuggestions[1].origin, .server)
+    }
+
+    // MARK: - Swift_prong1_ocr_preliminary — OCR chips as first-class preliminaries
+
+    func testLoadPreliminaryFromOnDeviceEmitsOCRChipWhenHighConfidence() {
+        let cls = classifications([("screw", 0.91)])
+        let ocr = ocrResults([("Elegoo Multicolored Ribbon Cables Kit", 1.0)])
+
+        sut.loadPreliminaryFromOnDevice(classifications: cls, ocr: ocr, topK: 3)
+
+        XCTAssertEqual(sut.editableSuggestions.count, 2,
+                       "Classifier + qualifying OCR entry should produce two chips")
+        XCTAssertEqual(sut.editableSuggestions.last?.editedName, "Elegoo Multicolored Ribbon Cables Kit")
+        XCTAssertEqual(sut.editableSuggestions.last?.origin, .ocr,
+                       "OCR chip must carry .ocr origin so merge() keeps it")
+    }
+
+    func testLoadPreliminaryFromOnDeviceSkipsOCRBelowConfidenceThreshold() {
+        let ocr = ocrResults([("Genuine Product Label", 0.85)])
+
+        sut.loadPreliminaryFromOnDevice(
+            classifications: [],
+            ocr: ocr,
+            topK: 3,
+            minOCRConfidence: 0.9
+        )
+
+        XCTAssertTrue(sut.editableSuggestions.isEmpty,
+                      "OCR below confidence threshold must not produce a chip")
+    }
+
+    func testLoadPreliminaryFromOnDeviceSkipsOCRBelowMinLength() {
+        let ocr = ocrResults([("New", 1.0), ("Hi", 1.0)])
+
+        sut.loadPreliminaryFromOnDevice(
+            classifications: [],
+            ocr: ocr,
+            topK: 3,
+            minOCRLength: 4
+        )
+
+        XCTAssertTrue(sut.editableSuggestions.isEmpty,
+                      "Short OCR strings must not produce a chip even at confidence 1.0")
+    }
+
+    func testLoadPreliminaryFromOnDeviceSelectsLongestQualifyingLine() {
+        let ocr = ocrResults([
+            ("Kit", 1.0),                                          // too short
+            ("Elegoo", 0.95),                                      // qualifies, short
+            ("Elegoo 120pcs Multicolored Ribbon Cables", 0.95),    // qualifies, longest
+            ("Elegoo Kit", 0.95)                                   // qualifies, middle
+        ])
+
+        sut.loadPreliminaryFromOnDevice(
+            classifications: [],
+            ocr: ocr,
+            topK: 3
+        )
+
+        XCTAssertEqual(sut.editableSuggestions.count, 1)
+        XCTAssertEqual(sut.editableSuggestions.first?.editedName,
+                       "Elegoo 120pcs Multicolored Ribbon Cables",
+                       "Among qualifying OCR entries, the longest text wins")
+    }
+
+    func testLoadPreliminaryFromOnDeviceTrimsWhitespaceBeforeLengthCheck() {
+        let ocr = ocrResults([("   Hi   ", 1.0)])
+
+        sut.loadPreliminaryFromOnDevice(
+            classifications: [],
+            ocr: ocr,
+            topK: 3,
+            minOCRLength: 4
+        )
+
+        XCTAssertTrue(sut.editableSuggestions.isEmpty,
+                      "Whitespace must be trimmed before the length check")
+    }
+
+    func testOCRPreliminarySurvivesServerEmpty() throws {
+        let ocr = ocrResults([("Elegoo 120pcs Multicolored Ribbon Cables", 1.0)])
+        sut.loadPreliminaryFromOnDevice(classifications: [], ocr: ocr, topK: 3)
+
+        sut.applyServerSuggestions([])
+
+        XCTAssertEqual(sut.editableSuggestions.count, 1,
+                       "OCR chip must survive an empty server response")
+        XCTAssertEqual(sut.editableSuggestions.first?.origin, .ocr)
+    }
+
+    func testOCRPreliminarySurvivesServerDisagrees() throws {
+        let ocr = ocrResults([("Elegoo 120pcs Multicolored Ribbon Cables", 1.0)])
+        sut.loadPreliminaryFromOnDevice(classifications: [], ocr: ocr, topK: 3)
+        let server = try serverItems(["label_packaging"])
+
+        sut.applyServerSuggestions(server)
+
+        XCTAssertEqual(sut.editableSuggestions.count, 2,
+                       "OCR chip survives; server chip is appended")
+        XCTAssertEqual(sut.editableSuggestions[0].origin, .ocr)
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "Elegoo 120pcs Multicolored Ribbon Cables")
+        XCTAssertEqual(sut.editableSuggestions[1].origin, .server)
+        XCTAssertEqual(sut.editableSuggestions[1].editedName, "label_packaging")
+    }
+
+    func testOCRPreliminaryDedupesAgainstServerName() throws {
+        let ocr = ocrResults([("bolt washer kit", 0.95)])
+        sut.loadPreliminaryFromOnDevice(classifications: [], ocr: ocr, topK: 3)
+        let server = try serverItems(["bolt washer kit", "screw"])
+
+        sut.applyServerSuggestions(server)
+
+        XCTAssertEqual(sut.editableSuggestions.count, 2,
+                       "Server entry overlapping an OCR chip must be deduped")
+        XCTAssertEqual(sut.editableSuggestions[0].editedName, "bolt washer kit")
+        XCTAssertEqual(sut.editableSuggestions[0].origin, .ocr,
+                       "OCR chip wins over the overlapping server entry")
+        XCTAssertEqual(sut.editableSuggestions[1].editedName, "screw")
+        XCTAssertEqual(sut.editableSuggestions[1].origin, .server)
+    }
+
+    func testLoadPreliminaryFromOnDeviceStillRendersClassifierChipsWhenNoOCRQualifies() {
+        let cls = classifications([("screw", 0.91), ("nail", 0.62)])
+        let ocr = ocrResults([("x", 0.5)])  // fails both bars
+
+        sut.loadPreliminaryFromOnDevice(classifications: cls, ocr: ocr, topK: 3)
+
+        XCTAssertEqual(sut.editableSuggestions.map(\.editedName), ["screw", "nail"])
+        XCTAssertTrue(sut.editableSuggestions.allSatisfy { $0.origin == .preliminary })
     }
 
     // MARK: - Pure merge function


### PR DESCRIPTION
## Why

Rich on-device OCR was being captured by the pipeline and shipped to the server, but **the user never saw it** in the Review Items chips. The classifier-derived "preliminary" chip set was the only thing that survived a round-trip, and when the server returned a weak match, the weak match won.

**Repro — Elegoo ribbon-cables box:**
- Device OCR: `"Elegoo 120pcs Multicolored Ribbon Cables Kit for arduino"` @ confidence 1.0
- Server `/suggest`: `{name: "label_packaging", match: {name: "box"}}`
- User saw: a `box` chip. The rich local OCR never surfaced.

Two-prong plan from the investigation:
- **Prong 1 (this PR):** iOS *uses* its own OCR findings to build preliminary chips — "always show the user what the device saw."
- **Prong 2 (deferred):** server-side bbox-driven match verification so weak matches stop winning.

## What (shape (a))

Preliminary chips now include an optional OCR-derived chip alongside the classifier chips.

A new `ChipOrigin.ocr` case is added. The pure `SuggestionReviewViewModel.merge(preliminary:server:)` function is widened so the "survivor" predicate keeps `.edited || .ocr` chips, not just `.edited`. Overlap with server entries is deduped via the *existing* normalized-name set mechanism — no new dedupe path.

### OCR preprocessing rule

- Pick the **longest contiguous OCR line** where:
  - `confidence >= 0.9`
  - `trimmed length >= 4 chars`
- Emit **zero or one** OCR chip per photo.
- If nothing qualifies, emit nothing — classifier chips still render.

**Deviation from spec:** the original dispatch suggested a fallback to "highest-confidence single entry if no line meets the length+confidence bar." I chose **not** to implement that fallback: it would relax the primary confidence bar below 0.9 and risk promoting low-quality chips. Classifier chips remain as the no-OCR baseline. Happy to revisit if the in-field data says the primary bar is too strict.

## What this PR does NOT do

- **No bbox enrichment of server matches** — that's Prong 2 (server-side), parked.
- **No barcode preliminary chips** — parked follow-up; scope discipline.
- **No changes to server contract** — pure iOS-side behavior change.

## Parked follow-ups

1. **Prong 2:** server-side bbox-driven match verification (style of `S-MATCH-OCR-01`). Zero OCR-token overlap → server vetoes the match.
2. **Barcode preliminary chips + `/lookup` integration** once Prong 1 is de-risked.
3. **Multi-line OCR aggregation** if the single-longest-line rule proves too narrow in the field.

## Tests

All on `Bin Brain` scheme, iPhone 17 / iOS 26.4 simulator. `** TEST SUCCEEDED **`.

### `SuggestionReviewViewModelPreliminaryTests` — 9 new cases

- `EmitsOCRChipWhenHighConfidence`
- `SkipsOCRBelowConfidenceThreshold` (0.85 below 0.9 bar)
- `SkipsOCRBelowMinLength` (3-char OCR rejected)
- `SelectsLongestQualifyingLine`
- `TrimsWhitespaceBeforeLengthCheck`
- `OCRPreliminarySurvivesServerEmpty`
- `OCRPreliminarySurvivesServerDisagrees`
- `OCRPreliminaryDedupesAgainstServerName`
- `StillRendersClassifierChipsWhenNoOCRQualifies`

### `PureMergeOCRSurvivalTests` — new file, 6 `@MainActor` cases

Pins the `merge(preliminary:server:)` contract at the function boundary, independent of VM load paths:

- `testOCRChipSurvivesEmptyServerResponse`
- `testOCRChipSurvivesServerDisagrees`
- `testServerEntryMatchingOCRNameIsDeduped`
- `testOCRDedupeIsCaseAndWhitespaceInsensitive`
- `testEditedAndOCRChipsBothSurvive`
- `testUntouchedPreliminaryIsStillDroppedWhenOCRSurvives` — regression guard that `.ocr` survival doesn't accidentally resurrect untouched `.preliminary`.

## Files changed

- `ViewModels/SuggestionReviewViewModel.swift` — `.ocr` origin; `merge()` survivor predicate; new `loadPreliminaryFromOnDevice(classifications:ocr:topK:minOCRConfidence:minOCRLength:)`.
- `ViewModels/AnalysisViewModel.swift` — `preliminaryOCR: [OCRResult]` published alongside `preliminaryClassifications`.
- `Views/Cataloging/AnalysisProgressView.swift` — `onPreliminaryReady` callback signature widened to `([ClassificationResult], [OCRResult])`.
- `Views/Bins/BinDetailView.swift`, `Views/Bins/BinsListView.swift` — route OCR through the new callback to `loadPreliminaryFromOnDevice`.
- `Bin BrainTests/SuggestionReviewViewModelPreliminaryTests.swift` — 9 new cases.
- `Bin BrainTests/PureMergeOCRSurvivalTests.swift` — new file, 6 cases.

## Branch / worktree

- Branch: `feature/swift-prong1-ocr-preliminary`
- Worktree: `.worktrees/swift-prong1-ocr-preliminary/`
- Dispatch: `Swift_prong1_ocr_preliminary`
