### PR TITLE
Extract AnalysisStepView and ReviewStepView (audit Top-10 #1/#9 follow-up)

### DIFF
--- a/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift
@@ -285,64 +285,14 @@ struct BinDetailView: View {
     // MARK: - Analysis View
 
     private var analysisView: some View {
-        AnalysisProgressView(
-            viewModel: coordinator.analysisViewModel,
-            onComplete: { suggestions in
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                if coordinator.navigatedOnPreliminary {
-                    coordinator.reviewViewModel.applyServerSuggestions(
-                        suggestions,
-                        photoId: coordinator.analysisViewModel.lastPhotoId,
-                        visionModel: coordinator.analysisViewModel.lastVisionModel,
-                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                    )
-                } else {
-                    coordinator.reviewViewModel.loadSuggestions(
-                        suggestions,
-                        photoId: coordinator.analysisViewModel.lastPhotoId,
-                        visionModel: coordinator.analysisViewModel.lastVisionModel,
-                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                    )
-                    coordinator.path.append(.review)
-                }
-            },
-            onRetry: {
-                // Finding #4-UX-2: "Retake Photo" must return to the camera so
-                // the user can capture a fresh frame.
-                coordinator.catalogingSession.recordRetake()
-                coordinator.analysisViewModel.reset()
-                coordinator.navigatedOnPreliminary = false
-                coordinator.capturedPhotoData = nil
-                coordinator.path.removeAll()
-            },
-            onOverride: {
-                coordinator.catalogingSession.recordQualityBypass()
-                coordinator.startOverrideQualityGate(
-                    binId: binId,
-                    apiClient: apiClient,
-                    sessionManager: sessionManager,
-                    modelContext: modelContext
-                )
-            },
-            onPreliminaryReady: { classifications, ocr in
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                coordinator.reviewViewModel.loadPreliminaryFromOnDevice(
-                    classifications: classifications,
-                    ocr: ocr,
-                    topK: CatalogingCoordinator.preliminaryTopK
-                )
-                coordinator.navigatedOnPreliminary = true
-                coordinator.path.append(.review)
-            }
-        )
+        AnalysisStepView(coordinator: coordinator, binIdProvider: { binId })
     }
 
     // MARK: - Review View
 
     private var reviewView: some View {
-        return SuggestionReviewView(
-            viewModel: coordinator.reviewViewModel,
-            apiClient: apiClient,
+        ReviewStepView(
+            coordinator: coordinator,
             onDone: {
                 // Swift2_027 — pop the inner NavigationStack FIRST so the
                 // .analysis/.review pushes unwind before the fullScreenCover
@@ -353,40 +303,8 @@ struct BinDetailView: View {
                 coordinator.path = []
                 showCamera = false
                 Task { await viewModel.load(binId: binId, apiClient: apiClient) }
-            },
-            onRetryWithLargerModel: coordinator.nextModelAvailable ? {
-                coordinator.escalateModelAndReSuggest(apiClient: apiClient)
-            } : nil
-        )
-        // Swift2_018 — inject the durable outcomes queue + context so
-        // confirm() persists each outcomes POST instead of firing it as a
-        // one-shot detached Task. Both must be set before confirm() runs.
-        .onAppear {
-            coordinator.reviewViewModel.outcomeQueueManager = outcomeQueueManager
-            coordinator.reviewViewModel.outcomeQueueContext = modelContext
-        }
-        // Same fix as BinsListView: observe phase on the visible view, not the
-        // background AnalysisProgressView.
-        .onChange(of: coordinator.analysisViewModel.phase) { _, newPhase in
-            guard coordinator.navigatedOnPreliminary else { return }
-            switch newPhase {
-            case .complete:
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                coordinator.reviewViewModel.applyServerSuggestions(
-                    coordinator.analysisViewModel.suggestions,
-                    photoId: coordinator.analysisViewModel.lastPhotoId,
-                    visionModel: coordinator.analysisViewModel.lastVisionModel,
-                    promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                )
-            case .failed(let message):
-                // The review screen owns the alert because the parent owns the
-                // API call — without this hook the user would be stuck on a
-                // permanent "Working…" spinner with no way to resubmit.
-                coordinator.ingestErrorMessage = message
-            default:
-                break
             }
-        }
+        )
         .alert(
             "Analysis Failed",
             isPresented: Binding(

--- a/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/BinsListView.swift
@@ -225,65 +225,14 @@ struct BinsListView: View {
     // MARK: - Analysis View
 
     private var analysisView: some View {
-        AnalysisProgressView(
-            viewModel: coordinator.analysisViewModel,
-            onComplete: { suggestions in
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                if coordinator.navigatedOnPreliminary {
-                    coordinator.reviewViewModel.applyServerSuggestions(
-                        suggestions,
-                        photoId: coordinator.analysisViewModel.lastPhotoId,
-                        visionModel: coordinator.analysisViewModel.lastVisionModel,
-                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                    )
-                } else {
-                    coordinator.reviewViewModel.loadSuggestions(
-                        suggestions,
-                        photoId: coordinator.analysisViewModel.lastPhotoId,
-                        visionModel: coordinator.analysisViewModel.lastVisionModel,
-                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                    )
-                    coordinator.path.append(.review)
-                }
-            },
-            onRetry: {
-                // Finding #4-UX-2: "Retake Photo" must return to the camera so
-                // the user can capture a fresh frame.
-                coordinator.catalogingSession.recordRetake()
-                coordinator.analysisViewModel.reset()
-                coordinator.navigatedOnPreliminary = false
-                coordinator.capturedPhotoData = nil
-                coordinator.path.removeAll()
-            },
-            onOverride: {
-                coordinator.catalogingSession.recordQualityBypass()
-                guard let binId = capturedBinId else { return }
-                coordinator.startOverrideQualityGate(
-                    binId: binId,
-                    apiClient: apiClient,
-                    sessionManager: sessionManager,
-                    modelContext: modelContext
-                )
-            },
-            onPreliminaryReady: { classifications, ocr in
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                coordinator.reviewViewModel.loadPreliminaryFromOnDevice(
-                    classifications: classifications,
-                    ocr: ocr,
-                    topK: CatalogingCoordinator.preliminaryTopK
-                )
-                coordinator.navigatedOnPreliminary = true
-                coordinator.path.append(.review)
-            }
-        )
+        AnalysisStepView(coordinator: coordinator, binIdProvider: { capturedBinId })
     }
 
     // MARK: - Review View
 
     private var reviewView: some View {
-        SuggestionReviewView(
-            viewModel: coordinator.reviewViewModel,
-            apiClient: apiClient,
+        ReviewStepView(
+            coordinator: coordinator,
             onDone: {
                 // Swift2_027 — pop the inner NavigationStack FIRST so the
                 // .analysis/.review pushes unwind before the fullScreenCover
@@ -291,41 +240,8 @@ struct BinsListView: View {
                 coordinator.path = []
                 showCataloging = false
                 Task { await viewModel.load(apiClient: apiClient) }
-            },
-            onRetryWithLargerModel: coordinator.nextModelAvailable ? {
-                coordinator.escalateModelAndReSuggest(apiClient: apiClient)
-            } : nil
-        )
-        // Swift2_018 — inject the durable outcomes queue + context so
-        // confirm() persists each outcomes POST instead of firing it as a
-        // one-shot detached Task. Both must be set before confirm() runs.
-        .onAppear {
-            coordinator.reviewViewModel.outcomeQueueManager = outcomeQueueManager
-            coordinator.reviewViewModel.outcomeQueueContext = modelContext
-        }
-        // AnalysisProgressView.onChange(of: phase) is unreliable when that view is
-        // in the NavigationStack background (non-visible destination). Observe here
-        // on the active visible view so server suggestions always land.
-        .onChange(of: coordinator.analysisViewModel.phase) { _, newPhase in
-            guard coordinator.navigatedOnPreliminary else { return }
-            switch newPhase {
-            case .complete:
-                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
-                coordinator.reviewViewModel.applyServerSuggestions(
-                    coordinator.analysisViewModel.suggestions,
-                    photoId: coordinator.analysisViewModel.lastPhotoId,
-                    visionModel: coordinator.analysisViewModel.lastVisionModel,
-                    promptVersion: coordinator.analysisViewModel.lastPromptVersion
-                )
-            case .failed(let message):
-                // The review screen owns the alert because the parent owns the
-                // API call — without this hook the user would be stuck on a
-                // permanent "Working…" spinner with no way to resubmit.
-                coordinator.ingestErrorMessage = message
-            default:
-                break
             }
-        }
+        )
         .alert(
             "Analysis Failed",
             isPresented: Binding(

--- a/Bin Brain/Bin Brain/Views/Bins/Components/AnalysisStepView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/Components/AnalysisStepView.swift
@@ -1,0 +1,81 @@
+// AnalysisStepView.swift
+// Bin Brain
+//
+// Reusable analysis-step destination shared by BinDetailView and BinsListView.
+
+import SwiftUI
+import SwiftData
+
+// MARK: - AnalysisStepView
+
+/// Wraps `AnalysisProgressView` with the shared cataloging-coordinator logic.
+///
+/// Both `BinDetailView` and `BinsListView` push this view as the `.analysis`
+/// destination in their `NavigationStack`. The only host-specific difference is
+/// the binId source: pass `binIdProvider: { binId }` (always non-nil) from
+/// `BinDetailView`, or `binIdProvider: { capturedBinId }` (may be nil) from
+/// `BinsListView`. The guard inside `onOverride` handles the nil case safely.
+struct AnalysisStepView: View {
+
+    let coordinator: CatalogingCoordinator
+    /// Returns the bin ID for quality-gate override; nil causes the override to be a no-op.
+    let binIdProvider: () -> String?
+
+    @Environment(\.apiClient) private var apiClient
+    @Environment(\.sessionManager) private var sessionManager
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        AnalysisProgressView(
+            viewModel: coordinator.analysisViewModel,
+            onComplete: { suggestions in
+                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
+                if coordinator.navigatedOnPreliminary {
+                    coordinator.reviewViewModel.applyServerSuggestions(
+                        suggestions,
+                        photoId: coordinator.analysisViewModel.lastPhotoId,
+                        visionModel: coordinator.analysisViewModel.lastVisionModel,
+                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
+                    )
+                } else {
+                    coordinator.reviewViewModel.loadSuggestions(
+                        suggestions,
+                        photoId: coordinator.analysisViewModel.lastPhotoId,
+                        visionModel: coordinator.analysisViewModel.lastVisionModel,
+                        promptVersion: coordinator.analysisViewModel.lastPromptVersion
+                    )
+                    coordinator.path.append(.review)
+                }
+            },
+            onRetry: {
+                // Finding #4-UX-2: "Retake Photo" must return to the camera so
+                // the user can capture a fresh frame.
+                coordinator.catalogingSession.recordRetake()
+                coordinator.analysisViewModel.reset()
+                coordinator.navigatedOnPreliminary = false
+                coordinator.capturedPhotoData = nil
+                coordinator.path.removeAll()
+            },
+            onOverride: {
+                coordinator.catalogingSession.recordQualityBypass()
+                guard let binId = binIdProvider() else { return }
+                coordinator.startOverrideQualityGate(
+                    binId: binId,
+                    apiClient: apiClient,
+                    sessionManager: sessionManager,
+                    modelContext: modelContext
+                )
+            },
+            onPreliminaryReady: { classifications, ocr in
+                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
+                coordinator.reviewViewModel.loadPreliminaryFromOnDevice(
+                    classifications: classifications,
+                    ocr: ocr,
+                    topK: CatalogingCoordinator.preliminaryTopK
+                )
+                coordinator.navigatedOnPreliminary = true
+                coordinator.path.append(.review)
+            }
+        )
+    }
+}

--- a/Bin Brain/Bin Brain/Views/Bins/Components/ReviewStepView.swift
+++ b/Bin Brain/Bin Brain/Views/Bins/Components/ReviewStepView.swift
@@ -1,0 +1,69 @@
+// ReviewStepView.swift
+// Bin Brain
+//
+// Reusable review-step destination shared by BinDetailView and BinsListView.
+
+import SwiftUI
+import SwiftData
+
+// MARK: - ReviewStepView
+
+/// Wraps `SuggestionReviewView` with the shared cataloging-coordinator logic.
+///
+/// Both `BinDetailView` and `BinsListView` push this view as the `.review`
+/// destination in their `NavigationStack`. Host-specific cancel behavior
+/// (dismissing `showCamera` vs `showCataloging`) is handled by the parent's
+/// `.alert` — the parent keeps the "Analysis Failed" alert so its Cancel
+/// button can perform host-specific cleanup without triggering a reload.
+///
+/// `onDone` encapsulates the full completion path (path reset + flag clear +
+/// reload) for each host.
+struct ReviewStepView: View {
+
+    let coordinator: CatalogingCoordinator
+    let onDone: () -> Void
+
+    @Environment(\.apiClient) private var apiClient
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.outcomeQueueManager) private var outcomeQueueManager
+
+    var body: some View {
+        SuggestionReviewView(
+            viewModel: coordinator.reviewViewModel,
+            apiClient: apiClient,
+            onDone: onDone,
+            onRetryWithLargerModel: coordinator.nextModelAvailable ? {
+                coordinator.escalateModelAndReSuggest(apiClient: apiClient)
+            } : nil
+        )
+        // Swift2_018 — inject the durable outcomes queue + context so
+        // confirm() persists each outcomes POST instead of firing it as a
+        // one-shot detached Task. Both must be set before confirm() runs.
+        .onAppear {
+            coordinator.reviewViewModel.outcomeQueueManager = outcomeQueueManager
+            coordinator.reviewViewModel.outcomeQueueContext = modelContext
+        }
+        // Observe phase on the active visible view so server suggestions
+        // always land (AnalysisProgressView.onChange is unreliable when
+        // that view is in the NavigationStack background).
+        .onChange(of: coordinator.analysisViewModel.phase) { _, newPhase in
+            guard coordinator.navigatedOnPreliminary else { return }
+            switch newPhase {
+            case .complete:
+                coordinator.reviewViewModel.photoData = coordinator.analysisViewModel.lastUploadedPhotoData
+                coordinator.reviewViewModel.applyServerSuggestions(
+                    coordinator.analysisViewModel.suggestions,
+                    photoId: coordinator.analysisViewModel.lastPhotoId,
+                    visionModel: coordinator.analysisViewModel.lastVisionModel,
+                    promptVersion: coordinator.analysisViewModel.lastPromptVersion
+                )
+            case .failed(let message):
+                // Route to parent's alert; the parent owns the binId source
+                // needed for the Retry path and the host flag for Cancel.
+                coordinator.ingestErrorMessage = message
+            default:
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
Natural follow-up to PR #39's Top-10 #1 (`CatalogingCoordinator`) and Top-10 #9 (subview extraction). Completes the cataloging-flow modularization by extracting the duplicated SwiftUI subtree (`analysisView` + `reviewView` body-builders, plus the `.onChange(of: phase)` binding) shared between `BinsListView` and `BinDetailView` into two reusable views.

Audit ref: `thoughts/shared/agents/code-simplifier/2026-04-25-full-repo-audit.md` — Top-10 row 1 / Duplication cluster #1 (subview portion).

## Changes

| File | Δ |
|---|---|
| `Bin Brain/Bin Brain/Views/Bins/Components/AnalysisStepView.swift` | new (81 LOC) |
| `Bin Brain/Bin Brain/Views/Bins/Components/ReviewStepView.swift` | new (69 LOC) |
| `Bin Brain/Bin Brain/Views/Bins/BinDetailView.swift` | 558 → 476 |
| `Bin Brain/Bin Brain/Views/Bins/BinsListView.swift` | 444 → 360 |

Net: 158 insertions, 174 deletions. 4 files, single signed commit (`9574c74`).

## Design

- `AnalysisStepView` — wraps `AnalysisProgressView` with the four shared callbacks (`onComplete`, `onRetry`, `onOverride`, `onPreliminaryReady`). Takes `coordinator` plus a `binIdProvider: () -> String?` that absorbs the only host-specific divergence (BinDetailView's non-optional `binId` vs BinsListView's `capturedBinId`). Reads `apiClient`, `sessionManager`, `modelContext` from `@Environment`.
- `ReviewStepView` — wraps `SuggestionReviewView`, the `.onAppear` outcome-queue injection, and the `.onChange(of: coordinator.analysisViewModel.phase)` switch. Takes `coordinator` and an `onDone: () -> Void` closure (each host implements its own dismissal-and-reload).
- The `.alert("Analysis Failed", ...)` modifier stays in each parent — its Cancel button needs to clear a host-specific dismissal flag (`showCamera` vs `showCataloging`) without triggering the reload that `onDone` would.

## Verification

- Behavior unchanged. Each closure that lived inline in a parent now lives in the matching step view; the two known parent-specific divergences (override binId source, onDone dismissal flag) are absorbed by `binIdProvider` and `onDone` closures.
- `private(set)` visibility on coordinator state preserved.
- Build clean; zero new warnings.
- Full `Bin BrainTests` target: **586 passed / 0 failed / 15 skipped** (matches main baseline exactly).
- `git log %h %ae %G?` → `9574c74 sfeather@gmail.com G` (signed, GitHub-verified).

Reviewed by team-internal QA (binbrain-dev team-create workflow).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the internal architecture of the analysis and review workflow to improve code maintainability and reduce complexity. Enhanced component separation to streamline future feature development and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->