### PR TITLE
Make AnalysisViewModel fully @MainActor (generalize PR-D's partial annotation)

### DIFF
--- a/Bin Brain/Bin Brain/Services/BackgroundTaskRunner.swift
+++ b/Bin Brain/Bin Brain/Services/BackgroundTaskRunner.swift
@@ -22,11 +22,12 @@ protocol BackgroundTaskRunning: AnyObject, Sendable {
 
 /// Production impl — routes directly to `UIApplication.shared`.
 ///
-/// `begin` and `end` call `UIApplication.shared` synchronously, so the Swift
-/// compiler infers them (and the class) as `@MainActor`. The `init()` is
-/// explicitly `nonisolated` so instances can be created as stored-property
-/// defaults and in test contexts without requiring a main-actor hop.
-final class UIApplicationBackgroundTaskRunner: BackgroundTaskRunning, @unchecked Sendable {
+/// The class is explicitly `@MainActor` because `begin` and `end` call
+/// `UIApplication.shared`. The `init()` is explicitly `nonisolated` so
+/// instances can be created as stored-property defaults and in test contexts
+/// without requiring a main-actor hop.
+@MainActor
+final class UIApplicationBackgroundTaskRunner: BackgroundTaskRunning {
     nonisolated init() {}
 
     func begin(name: String, expirationHandler: @escaping @Sendable () -> Void) -> Int {

--- a/Bin Brain/Bin Brain/Services/BackgroundTaskRunner.swift
+++ b/Bin Brain/Bin Brain/Services/BackgroundTaskRunner.swift
@@ -21,7 +21,14 @@ protocol BackgroundTaskRunning: AnyObject, Sendable {
 }
 
 /// Production impl — routes directly to `UIApplication.shared`.
+///
+/// `begin` and `end` call `UIApplication.shared` synchronously, so the Swift
+/// compiler infers them (and the class) as `@MainActor`. The `init()` is
+/// explicitly `nonisolated` so instances can be created as stored-property
+/// defaults and in test contexts without requiring a main-actor hop.
 final class UIApplicationBackgroundTaskRunner: BackgroundTaskRunning, @unchecked Sendable {
+    nonisolated init() {}
+
     func begin(name: String, expirationHandler: @escaping @Sendable () -> Void) -> Int {
         let raw = UIApplication.shared.beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
         return raw.rawValue

--- a/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
+++ b/Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift
@@ -41,6 +41,7 @@ enum AnalysisPhase: Equatable {
 /// Call `run(jpegData:binId:apiClient:)` to start the full workflow.
 /// Phase changes are observable; bind to `phase` in `AnalysisProgressView`.
 @Observable
+@MainActor
 final class AnalysisViewModel {
 
     // MARK: - State
@@ -125,7 +126,7 @@ final class AnalysisViewModel {
 
     // MARK: - Initializer
 
-    init(backgroundTask: BackgroundTaskRunning = UIApplicationBackgroundTaskRunner()) {
+    nonisolated init(backgroundTask: BackgroundTaskRunning = UIApplicationBackgroundTaskRunner()) {
         self.backgroundTask = backgroundTask
     }
 
@@ -163,7 +164,6 @@ final class AnalysisViewModel {
     ///   - userBehavior: Optional cataloging-session supervision snapshot
     ///     (retake_count, quality_bypass_count). Forwarded into
     ///     `ImagePipeline.process` so it lands in `device_metadata.user_behavior`.
-    @MainActor
     func run(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, sessionManager: SessionManager? = nil, context: ModelContext? = nil, cameraContext: CameraCaptureContext? = nil, userBehavior: UserBehaviorContext? = nil, prescannedBarcode: BarcodeResult? = nil) async {
         lastQualityFailure = nil
         lastRejectedPhotoData = nil
@@ -336,7 +336,6 @@ final class AnalysisViewModel {
     ///     taken AFTER the bypass tap was recorded. When supplied, replaces
     ///     the stored snapshot from the original `run(...)` so the bypass
     ///     count reflects reality.
-    @MainActor
     func overrideQualityGate(jpegData: Data, binId: String, apiClient: APIClient, sessionId: UUID? = nil, sessionManager: SessionManager? = nil, context: ModelContext? = nil, userBehavior: UserBehaviorContext? = nil, prescannedBarcode: BarcodeResult? = nil) async {
         // Finding #19 — same BG task protection as run() so the #18 180 s
         // /suggest window doesn't get OS-killed if the user backgrounds
@@ -423,7 +422,6 @@ final class AnalysisViewModel {
     /// Requires a prior successful `run()` that set `lastPhotoId`.
     ///
     /// - Parameter apiClient: The `APIClient` instance to use for the suggest call.
-    @MainActor
     func reSuggest(apiClient: APIClient) async {
         guard let photoId = lastPhotoId else {
             phase = .failed("No photo to re-analyse")
@@ -557,15 +555,16 @@ final class AnalysisViewModel {
     /// 2. Transitions `phase` to `.failed("Analysis interrupted — tap to retry")` on the main actor.
     /// 3. Ends the background task grant (idempotent via `-1` sentinel).
     ///
-    /// - Note: Must be called from `@MainActor` to avoid data races on the
-    ///   background-task box between the `defer` block and the OS expiration handler.
+    /// - Note: Inherits `@MainActor` isolation from the class; the `defer` block
+    ///   and `body` run on the main actor. The expiration handler is invoked by
+    ///   the OS on an arbitrary thread and explicitly hops back via
+    ///   `Task { @MainActor [weak self] in ... }`.
     /// - Parameters:
     ///   - name: The background-task name passed to `BackgroundTaskRunning.begin`.
     ///   - onExpiry: Additional work to perform when the OS fires the expiration
     ///               handler. Runs before the phase transition. Defaults to a no-op.
     ///   - body: The async body to execute under the background-task grant.
     /// - Returns: The value produced by `body`.
-    @MainActor
     private func withBackgroundTask<T>(
         name: String,
         onExpiry: @escaping @Sendable () -> Void = {},


### PR DESCRIPTION
Generalizes PR #39's PR-D fix (which marked 4 specific methods on `AnalysisViewModel` as `@MainActor`) to the entire class.

Addresses bug5 from PR #39 review (coderabbitai): the doc comment on `withBackgroundTask` claimed it must be called from `@MainActor`, but the compiler didn't enforce it. With `@MainActor` on the class declaration, all instance methods now inherit main-actor isolation and the contract is statically guaranteed.

## Changes

| File | Δ | Why |
|---|---|---|
| `Bin Brain/Bin Brain/ViewModels/AnalysisViewModel.swift` | +6/−7 | `@MainActor` on class; 4 redundant per-method annotations removed; `nonisolated init(backgroundTask:)` so stored-property defaults compile; doc comment updated |
| `Bin Brain/Bin Brain/Services/BackgroundTaskRunner.swift` | +7 | `nonisolated init()` on `UIApplicationBackgroundTaskRunner` — Swift 6.3 inferred the class as `@MainActor` (it touches `UIApplication.shared` synchronously); the empty init body is `nonisolated` so default-parameter call sites compile clean |

## Why two `nonisolated` markers?

- `AnalysisViewModel.init(backgroundTask:)` — `CatalogingCoordinator` has `var analysisViewModel = AnalysisViewModel()` as a stored-property default. Stored-property defaults are evaluated in a synchronous nonisolated context, so the init must be `nonisolated` to be callable from that context.
- `UIApplicationBackgroundTaskRunner.init()` — same pattern. `AnalysisViewModel.init(backgroundTask: UIApplicationBackgroundTaskRunner = .init())` calls the runner's init from a default parameter, which is also a synchronous nonisolated context.

Both inits have empty/trivial bodies, so `nonisolated` is safe — they don't touch `@MainActor` state.

## What stayed

- `Task { @MainActor [weak self] in ... }` inside `withBackgroundTask`'s expiration handler is preserved. The OS background-task expiration handler runs OFF the main actor (arbitrary thread), so the hop back is still required.
- `nonisolated(unsafe)` on `WorkTaskBox.task` and `WorkTaskBox.suggestTask` is preserved — those are written from main and read from the OS expiration handler.

## Verification

- Build clean; zero new warnings vs main.
- Full `Bin BrainTests` target: **586 passed / 0 failed / 15 skipped** (baseline match).
- `git log %h %ae %G?` → `816b219 sfeather@gmail.com G` (signed, GitHub-verified).
- All external callers compile unchanged (CatalogingCoordinator, AnalysisStepView).

Reviewed by team-internal QA (binbrain-dev team-create workflow).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved main-thread isolation for background task handling and view-model operations to reduce concurrency issues.
  * Decoupled certain initializations from the main thread for more reliable startup and easier testing.
  * Clarified background-task documentation to note how OS expiration handlers interact with the main thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->